### PR TITLE
Fix small bugs

### DIFF
--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -143,7 +143,7 @@ namespace Modding
                 
                 foreach (var x in ModLoader.ModInstances)
                 {
-                    if (x.Mod is ITogglableMod && x.Error is not null) 
+                    if (x.Mod is ITogglableMod && x.Error is null) 
                         settings.ModEnabledSettings.Add(x.Name, x.Enabled);
                 }
                 

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -193,7 +193,7 @@ namespace Modding
             }
 
             ModInstance[] orderedMods = ModInstanceTypeMap.Values
-                .OrderBy(x => x.Mod.LoadPriority())
+                .OrderBy(x => x.Mod?.LoadPriority() ?? 0)
                 .ToArray();
 
             // dict<scene name, list<(mod, list<objectNames>)>


### PR DESCRIPTION
ModHooks: correctly save IToggleable mod status

ModLoader: don't blow up MAPI on constructor failure. I used [this mod](https://github.com/flibber-hk/HollowKnight.RecentItemsDisplay/tree/b8672d4275e294812ad705a2665f999c0fcc4eec) without ItemChanger installed (RecentItemsDisplay has an explicit dependence on ItemChanger), if you want an example case, though I think the error here is self-explanatory.