### PR TITLE
Use ReflectionHelper for get/set cstate

### DIFF
--- a/Assembly-CSharp/Patches/HeroControllerStates.cs
+++ b/Assembly-CSharp/Patches/HeroControllerStates.cs
@@ -1,0 +1,24 @@
+using MonoMod;
+
+// ReSharper disable All
+#pragma warning disable 1591
+#pragma warning disable CS0108, CS0626
+
+namespace Modding.Patches
+{
+    [MonoModPatch("global::HeroControllerStates")]
+    public class HeroControllerStates : global::HeroControllerStates
+    {
+        [MonoModReplace]
+        public bool GetState(string stateName)
+        {
+            return ReflectionHelper.GetField<HeroControllerStates, bool, bool?>(this, stateName, null).GetValueOrDefault();
+        }
+
+        [MonoModReplace]
+        public void SetState(string stateName, bool value)
+        {
+            ReflectionHelper.SetFieldSafe(this, stateName, value);
+        }
+    }
+}

--- a/Assembly-CSharp/ReflectionHelper.cs
+++ b/Assembly-CSharp/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -108,6 +108,7 @@ namespace Modding
             (
                 CacheFields<PlayerData>,
                 CacheFields<HeroController>,
+                CacheFields<HeroControllerStates>,
                 CacheFields<GameManager>,
                 CacheFields<UIManager>
             );
@@ -354,7 +355,7 @@ namespace Modding
         [PublicAPI]
         public static void SetField<TType, TField>(string name, TField value)
         {
-            ((Action<TField>) GetGetter<TType, TField>(GetFieldInfo(typeof(TType), name, false)))(value);
+            ((Action<TField>) GetSetter<TType, TField>(GetFieldInfo(typeof(TType), name, false)))(value);
         }
     }
 }


### PR DESCRIPTION
I don't really think it's necessary to have a modhook for this - since the cstate isn't saved, there's not really a reason to modify the result of the methods instead of simply modifying the cstate directly.

Actually that's not totally true - you may want to be able to log changes to the cstate, probably for research purposes I guess. But I don't think it's worth the hassle of modifying the prepatcher just for this specific use case.