### PR TITLE
Don't save modhooks global settings if mods haven't finished loading

### DIFF
--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -238,6 +238,7 @@ namespace Modding
             
             Logger.APILogger.LogDebug("Updated mod text.");
 
+            ModHooks.OnFinishedLoadingMods();
             Loaded = true;
 
             new ModListMenu().InitMenuCreation();


### PR DESCRIPTION
Fixes bug where all itogglable mods are set to false if the game is closed before modloading has finished - this can be reproduced by quitting out while a mod like [GeoLog](https://github.com/SFGrenade/GeoLog) is preloading.

I wrote it like this because I felt an event for after mods have finished loading might be useful; the natural use case would be to execute code that requires interoperability with other mods without needing to set your mod's load priority (although I guess it's also concievable that a mod might want to be an early subscriber to one event and a late subscriber to another).

(The alternative fix could be to simply check ModLoader.Loaded before saving global settings, I guess)