### PR TITLE
Make the new application of AfterTakeDamage only be raised when it should

### DIFF
--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -1220,14 +1220,14 @@ namespace Modding
         }
 
         /// <summary>
-        ///     Called when damage is dealt to the player
+        ///     Called when damage is dealt to the player, at the start of the take damage function.
         /// </summary>
         /// <see cref="TakeDamageProxy"/>
         /// <remarks>HeroController.TakeDamage</remarks>
         public static event TakeDamageProxy TakeDamageHook;
 
         /// <summary>
-        ///     Called when damage is dealt to the player
+        ///     Called when damage is dealt to the player, at the start of the take damage function.
         /// </summary>
         /// <remarks>HeroController.TakeDamage</remarks>
         internal static int OnTakeDamage(ref int hazardType, int damage)
@@ -1257,13 +1257,13 @@ namespace Modding
         }
 
         /// <summary>
-        ///     Called at the end of the take damage function
+        ///     Called in the take damage function, immediately before applying damage (just before checking overcharm)
         /// </summary>
         /// <see cref="AfterTakeDamageHandler"/>
         public static event AfterTakeDamageHandler AfterTakeDamageHook;
 
         /// <summary>
-        ///     Called at the end of the take damage function
+        ///     Called in the take damage function, immediately before applying damage (just before checking overcharm)
         /// </summary>
         internal static int AfterTakeDamage(int hazardType, int damageAmount)
         {

--- a/Assembly-CSharp/Patches/HeroController.cs
+++ b/Assembly-CSharp/Patches/HeroController.cs
@@ -651,7 +651,6 @@ namespace Modding.Patches
                         }
                     }
 
-                    damageAmount = ModHooks.AfterTakeDamage(hazardType, damageAmount);
                     if (this.playerData.GetBool("equippedCharm_5") && this.playerData.GetInt("blockerHits") > 0 && hazardType == 1 && this.cState.focusing && !flag)
                     {
                         this.proxyFSM.SendEvent("HeroCtrl-TookBlockerHit");
@@ -698,6 +697,7 @@ namespace Modding.Patches
                         this.audioCtrl.PlaySound(HeroSounds.TAKE_HIT);
                     }
 
+                    damageAmount = ModHooks.AfterTakeDamage(hazardType, damageAmount);
                     if (!this.takeNoDamage && !this.playerData.GetBool("invinciTest"))
                     {
                         if (this.playerData.GetBool("overcharmed"))
@@ -765,12 +765,11 @@ namespace Modding.Patches
                 }
                 else if (this.cState.invulnerable && !this.cState.hazardDeath && !this.playerData.GetBool("isInvincible"))
                 {
-                    damageAmount = ModHooks.AfterTakeDamage(hazardType, damageAmount);
-
                     if (hazardType == 2)
                     {
                         if (!this.takeNoDamage)
                         {
+                            damageAmount = ModHooks.AfterTakeDamage(hazardType, damageAmount);
                             this.playerData.TakeHealth(damageAmount);
                         }
 
@@ -787,6 +786,7 @@ namespace Modding.Patches
                     }
                     else if (hazardType == 3)
                     {
+                        damageAmount = ModHooks.AfterTakeDamage(hazardType, damageAmount);
                         this.playerData.TakeHealth(damageAmount);
                         this.proxyFSM.SendEvent("HeroCtrl-HeroDamaged");
                         if (this.playerData.GetInt("health") == 0)


### PR DESCRIPTION
Problem: the previous commit was raising AfterTakeDamage whenever the knight took damage while invulnerable. That part of the routine only does anything if the hazardtype is 2(spikes) or 3(acid). It's dishonest, therefore, to raise it when hazardtype is 1(enemy) for example, because the game wasn't going to deal damage anyway. I think it's best to raise the event if the damage was going to be dealt - actually, the current behaviour raises the event if the knight wasn't going to take damage by virtue of having pd.InvinciTest or hc.takeNoDamage be true, but I think it's better to raise the event and force devs to check those fields if they really care (which is unlikely - InvinciTest isn't set in normal gameplay and takeNoDamage is only set in void heart climb as far as I can tell) to allow the modified damage amount to affect Grubsong, Joni Beam and the OnTakenDamage event.