### PR TITLE
Avoid throwing when constructing mods with soft dependencies missing

### DIFF
--- a/Assembly-CSharp/AssemblyExtensions.cs
+++ b/Assembly-CSharp/AssemblyExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Modding.Extensions
+namespace Modding
 {
     /// <summary>
     /// Class containing extensions used by the Modding API for dealing with assemblies.

--- a/Assembly-CSharp/Extensions/AssemblyExtensions.cs
+++ b/Assembly-CSharp/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Modding.Extensions
+{
+    /// <summary>
+    /// Class containing extensions used by the Modding API for dealing with assemblies.
+    /// </summary>
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        /// Returns a collection containing the types in the provided assembly.
+        /// If some types cannot be loaded (e.g. they derive from a type in an uninstalled mod),
+        /// then only the successfully loaded types are returned.
+        /// </summary>
+        public static IEnumerable<Type> GetTypesSafely(this Assembly asm)
+        {
+            try
+            {
+                return asm.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(x => x is not null);
+            }
+        }
+    }
+}

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -12,6 +12,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UObject = UnityEngine.Object;
 using USceneManager = UnityEngine.SceneManagement.SceneManager;
+using Modding.Extensions;
 
 namespace Modding
 {
@@ -139,7 +140,7 @@ namespace Modding
                 
                 try
                 {
-                    foreach (Type ty in asm.GetTypes())
+                    foreach (Type ty in asm.GetTypesSafely())
                     {
                         if (!ty.IsClass || ty.IsAbstract || !ty.IsSubclassOf(typeof(Mod))) 
                             continue;    

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -12,7 +12,6 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UObject = UnityEngine.Object;
 using USceneManager = UnityEngine.SceneManagement.SceneManager;
-using Modding.Extensions;
 
 namespace Modding
 {


### PR DESCRIPTION
The particular error this addresses is when some types in the assembly derive from types that are unavailable. This way, it is safe to define types derived from types in external mods when the external mods might not be available.