### PR TITLE
Utilize vanilla localization for menus

### DIFF
--- a/Assembly-CSharp/Menu/Content/StaticContent.cs
+++ b/Assembly-CSharp/Menu/Content/StaticContent.cs
@@ -80,6 +80,7 @@ namespace Modding.Menu
                 TextPanelConfig.TextFont.TrajanRegular => MenuResources.TrajanRegular,
                 TextPanelConfig.TextFont.TrajanBold => MenuResources.TrajanBold,
                 TextPanelConfig.TextFont.Perpetua => MenuResources.Perpetua,
+                TextPanelConfig.TextFont.NotoSerifCJKSCRegular => MenuResources.NotoSerifCJKSCRegular,
                 _ => MenuResources.TrajanRegular
             };
             text.supportRichText = true;
@@ -207,7 +208,7 @@ namespace Modding.Menu
             public TextAnchor Anchor;
 
             /// <summary>
-            /// The three main fonts that Hollow Knight uses in the menus.
+            /// The four main fonts that Hollow Knight uses in the menus.
             /// </summary>
             public enum TextFont
             {
@@ -222,7 +223,11 @@ namespace Modding.Menu
                 /// <summary>
                 /// The perpetua font.
                 /// </summary>
-                Perpetua
+                Perpetua,
+                /// <summary>
+                /// The Noto Serif CJK SC regular font.
+                /// </summary>
+                NotoSerifCJKSCRegular,
             }
         }
     }

--- a/Assembly-CSharp/Menu/MenuResources.cs
+++ b/Assembly-CSharp/Menu/MenuResources.cs
@@ -14,6 +14,7 @@ namespace Modding.Menu
         public static Font TrajanRegular { get; private set; }
         public static Font TrajanBold { get; private set; }
         public static Font Perpetua { get; private set; }
+        public static Font NotoSerifCJKSCRegular { get; private set; }
 
         public static RuntimeAnimatorController MenuTopFleurAnimator { get; private set; }
         public static RuntimeAnimatorController MenuCursorAnimator { get; private set; }
@@ -72,6 +73,9 @@ namespace Modding.Menu
                             break;
                         case "Perpetua":
                             Perpetua = font;
+                            break;
+                        case "NotoSerifCJKsc-Regular":
+                            NotoSerifCJKSCRegular = font;
                             break;
                     }
             }

--- a/Assembly-CSharp/Menu/MenuUtils.cs
+++ b/Assembly-CSharp/Menu/MenuUtils.cs
@@ -8,6 +8,7 @@ using Modding.Menu.Config;
 using UnityEngine;
 using UnityEngine.UI;
 using Patch = Modding.Patches;
+using Lang = Language.Language;
 
 
 namespace Modding.Menu
@@ -66,7 +67,7 @@ namespace Modding.Menu
                     "BackButton",
                     new MenuButtonConfig
                     {
-                        Label = "Back",
+                        Label = Lang.Get("NAV_BACK", "MainMenu"),
                         CancelAction = _ => ((Patch.UIManager)UIManager.instance).UIGoToDynamicMenu(returnScreen),
                         SubmitAction = _ => ((Patch.UIManager)UIManager.instance).UIGoToDynamicMenu(returnScreen),
                         Proceed = true,

--- a/Assembly-CSharp/ModListMenu.cs
+++ b/Assembly-CSharp/ModListMenu.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using static Modding.ModLoader;
 using Patch = Modding.Patches;
+using Lang = Language.Language;
 
 namespace Modding
 {
@@ -92,14 +93,17 @@ namespace Modding
                                                         },
                                                         CancelAction = _ => this.ApplyChanges(),
                                                         Label = modInst.Name,
-                                                        Options = new string[] { "Off", "On" },
+                                                        Options = new string[] {
+                                                            Lang.Get("MOH_OFF", "MainMenu"),
+                                                            Lang.Get("MOH_ON", "MainMenu")
+                                                        },
                                                         RefreshSetting = (self, apply) => self.optionList.SetOptionTo(
                                                             modInst.Enabled ? 1 : 0
                                                         ),
                                                         Style = HorizontalOptionStyle.VanillaStyle,
                                                         Description = new DescriptionInfo
                                                         {
-                                                            Text = $"Version {modInst.Mod.GetVersion()}"
+                                                            Text = $"v{modInst.Mod.GetVersion()}"
                                                         }
                                                     },
                                                     out var opt
@@ -140,13 +144,13 @@ namespace Modding
                                                 {
                                                     Style = MenuButtonStyle.VanillaStyle,
                                                     CancelAction = _ => this.ApplyChanges(),
-                                                    Label = toggleDels == null ? $"{modInst.Name} Settings" : modInst.Name,
+                                                    Label = toggleDels == null ? $"{modInst.Name} {Lang.Get("MAIN_OPTIONS", "MainMenu")}" : modInst.Name,
                                                     SubmitAction = _ => ((Patch.UIManager)UIManager.instance)
                                                         .UIGoToDynamicMenu(menu),
                                                     Proceed = true,
                                                     Description = new DescriptionInfo
                                                     {
-                                                        Text = $"Version {modInst.Mod.GetVersion()}"
+                                                        Text = $"v{modInst.Mod.GetVersion()}"
                                                     }
                                                 }
                                             );
@@ -169,13 +173,13 @@ namespace Modding
                                                 {
                                                     Style = MenuButtonStyle.VanillaStyle,
                                                     CancelAction = _ => this.ApplyChanges(),
-                                                    Label = toggleDels == null ? $"{modInst.Name} Settings" : modInst.Name,
+                                                    Label = toggleDels == null ? $"{modInst.Name} {Lang.Get("MAIN_OPTIONS", "MainMenu")}" : modInst.Name,
                                                     SubmitAction = _ => ((Patch.UIManager)UIManager.instance)
                                                         .UIGoToDynamicMenu(menu),
                                                     Proceed = true,
                                                     Description = new DescriptionInfo
                                                     {
-                                                        Text = $"Version {modInst.Mod.GetVersion()}"
+                                                        Text = $"v{modInst.Mod.GetVersion()}"
                                                     }
                                                 }
                                             );
@@ -200,7 +204,7 @@ namespace Modding
                             "BackButton",
                             new MenuButtonConfig
                             {
-                                Label = "Back",
+                                Label = Lang.Get("NAV_BACK", "MainMenu"),
                                 CancelAction = _ => this.ApplyChanges(),
                                 SubmitAction = _ => this.ApplyChanges(),
                                 Proceed = true,
@@ -268,7 +272,10 @@ namespace Modding
             IMenuMod.MenuEntry? toggleEntry = toggleDelegates is ModToggleDelegates dels ? new IMenuMod.MenuEntry
             {
                 Name = modInst.Name,
-                Values = new string[] { "Off", "On" },
+                Values = new string[] {
+                    Lang.Get("MOH_OFF", "MainMenu"),
+                    Lang.Get("MOH_ON", "MainMenu")
+                },
                 Saver = v => dels.SetModEnabled(v == 1),
                 Loader = () => dels.GetModEnabled() ? 1 : 0,
             } : null;


### PR DESCRIPTION
Utilize vanilla `Language.Language.Get` for menu texts. "Version" is currently replcaed with "v", which is language-independent, since vanilla does not contain localization for it.