### PR TITLE
Add more logging to mod loading

### DIFF
--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -235,8 +235,9 @@ namespace Modding
             UObject.DontDestroyOnLoad(version);
             
             UpdateModText();
-            
-            Logger.APILogger.LogDebug("Updated mod text.");
+
+            // Adding version nums to the modlog by default to make debugging significantly easier
+            Logger.APILogger.Log("Set mod text:\n" + modVersionDraw.drawString);
 
             ModHooks.OnFinishedLoadingMods();
             Loaded = true;
@@ -260,7 +261,15 @@ namespace Modding
                 }
                 Logger.APILogger.LogDebug($"Checking preloads for mod \"{mod.Mod.GetName()}\"");
 
-                List<(string, string)> preloadNames = mod.Mod.GetPreloadNames();
+                List<(string, string)> preloadNames = null;
+                try
+                {
+                    preloadNames = mod.Mod.GetPreloadNames();
+                }
+                catch (Exception ex)
+                {
+                    Logger.APILogger.LogError($"Error getting preload names for mod {mod.Name}\n" + ex);
+                }
                 if (preloadNames == null)
                 {
                     continue;

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -237,7 +237,7 @@ namespace Modding
             UpdateModText();
 
             // Adding version nums to the modlog by default to make debugging significantly easier
-            Logger.APILogger.LogDebug("Set mod text:\n" + modVersionDraw.drawString);
+            Logger.APILogger.Log("Finished loading mods:\n" + modVersionDraw.drawString);
 
             ModHooks.OnFinishedLoadingMods();
             Loaded = true;

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -237,7 +237,7 @@ namespace Modding
             UpdateModText();
 
             // Adding version nums to the modlog by default to make debugging significantly easier
-            Logger.APILogger.Log("Set mod text:\n" + modVersionDraw.drawString);
+            Logger.APILogger.LogDebug("Set mod text:\n" + modVersionDraw.drawString);
 
             ModHooks.OnFinishedLoadingMods();
             Loaded = true;


### PR DESCRIPTION
The types of errors addressed by try-catch on GetPreloadNames are rare but came up in #rando-general last week and the added error message would have been useful.
Including version names can also help diagnose obscure errors when it's not clear which mod is responsible for the errors.