### PR TITLE
Fix one source of menu softlocks

### DIFF
--- a/Assembly-CSharp/ModListMenu.cs
+++ b/Assembly-CSharp/ModListMenu.cs
@@ -225,7 +225,7 @@ namespace Modding
                                 "ModMenuButton",
                                 new MenuButtonConfig
                                 {
-                                    CancelAction = self => UIManager.instance.UIGoToMainMenu(),
+                                    CancelAction = self => UIManager.instance.UILeaveOptionsMenu(),
                                     Label = "Mods",
                                     SubmitAction = GoToModListMenu,
                                     Proceed = true,


### PR DESCRIPTION
This addresses the issue where they press the back button (focus key) while the Mods button is selected, while in-game rather than in menu.