### PR TITLE
Extensions

### DIFF
--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -12,6 +12,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UObject = UnityEngine.Object;
 using USceneManager = UnityEngine.SceneManagement.SceneManager;
+using Modding.Utils;
 
 namespace Modding
 {

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -208,11 +208,7 @@ namespace Modding
             GetPreloads(orderedMods, scenes, toPreload);
             if (toPreload.Count > 0)
             {
-                Preloader pld = coroutineHolder.GetComponent<Preloader>();
-                if (pld == null)
-                {
-                    pld = coroutineHolder.AddComponent<Preloader>();
-                }
+                Preloader pld = coroutineHolder.GetOrAddComponent<Preloader>();
                 yield return pld.Preload(toPreload, preloadedObjects);
             }
 

--- a/Assembly-CSharp/Patches/HeroController.cs
+++ b/Assembly-CSharp/Patches/HeroController.cs
@@ -107,11 +107,11 @@ namespace Modding.Patches
 
                             if (this.playerData.equippedCharm_13)
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, this.MANTIS_CHARM_SCALE);
+                                this.grubberFlyBeam.transform.SetScaleY(this.MANTIS_CHARM_SCALE);
                             }
                             else
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, 1f);
+                                this.grubberFlyBeam.transform.SetScaleY(1f);
                             }
                         }
 
@@ -128,11 +128,11 @@ namespace Modding.Patches
 
                             if (this.playerData.equippedCharm_13)
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, this.MANTIS_CHARM_SCALE);
+                                this.grubberFlyBeam.transform.SetScaleY(this.MANTIS_CHARM_SCALE);
                             }
                             else
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, 1f);
+                                this.grubberFlyBeam.transform.SetScaleY(1f);
                             }
                         }
                     }
@@ -147,22 +147,22 @@ namespace Modding.Patches
                         if ((this.playerData.health == this.playerData.maxHealth && !this.playerData.equippedCharm_27) || (this.joniBeam && this.playerData.equippedCharm_27))
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabU.Spawn(this.transform.position);
-                            Extensions.SetScaleY(this.grubberFlyBeam.transform, this.transform.localScale.x);
+                            this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 270f);
                             if (this.playerData.equippedCharm_13)
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
+                                this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
                         }
 
                         if (this.playerData.health == 1 && this.playerData.equippedCharm_6 && this.playerData.healthBlue < 1)
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabU_fury.Spawn(this.transform.position);
-                            Extensions.SetScaleY(this.grubberFlyBeam.transform, this.transform.localScale.x);
+                            this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 270f);
                             if (this.playerData.equippedCharm_13)
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
+                                this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
                         }
                     }
@@ -177,22 +177,22 @@ namespace Modding.Patches
                         if ((this.playerData.health == this.playerData.maxHealth && !this.playerData.equippedCharm_27) || (this.joniBeam && this.playerData.equippedCharm_27))
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabD.Spawn(this.transform.position);
-                            Extensions.SetScaleY(this.grubberFlyBeam.transform, this.transform.localScale.x);
+                            this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 90f);
                             if (this.playerData.equippedCharm_13)
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
+                                this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
                         }
 
                         if (this.playerData.health == 1 && this.playerData.equippedCharm_6 && this.playerData.healthBlue < 1)
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabD_fury.Spawn(this.transform.position);
-                            Extensions.SetScaleY(this.grubberFlyBeam.transform, this.transform.localScale.x);
+                            this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 90f);
                             if (this.playerData.equippedCharm_13)
                             {
-                                Extensions.SetScaleY(this.grubberFlyBeam.transform, this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
+                                this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
                         }
                     }

--- a/Assembly-CSharp/Preloader.cs
+++ b/Assembly-CSharp/Preloader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -179,7 +180,16 @@ internal class Preloader : MonoBehaviour
                 {
                     Logger.APILogger.LogFine($"Fetching object \"{objName}\"");
 
-                    GameObject obj = UnityExtensions.GetGameObjectFromArray(rootObjects, objName);
+                    GameObject obj = null;
+                    try
+                    {
+                        obj = UnityExtensions.GetGameObjectFromArray(rootObjects, objName);
+                    }
+                    catch (ArgumentException)
+                    {
+                        Logger.APILogger.LogWarn($"Invalid GameObject name {objName}");
+                        continue;
+                    }
                     if (obj == null)
                     {
                         Logger.APILogger.LogWarn(

--- a/Assembly-CSharp/Preloader.cs
+++ b/Assembly-CSharp/Preloader.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -6,6 +6,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UObject = UnityEngine.Object;
 using USceneManager = UnityEngine.SceneManagement.SceneManager;
+using Modding.Utils;
 
 namespace Modding;
 
@@ -178,51 +179,13 @@ internal class Preloader : MonoBehaviour
                 {
                     Logger.APILogger.LogFine($"Fetching object \"{objName}\"");
 
-                    // Split object name into root and child names based on '/'
-                    string rootName;
-                    string childName = null;
-
-                    int slashIndex = objName.IndexOf('/');
-                    if (slashIndex == -1)
-                    {
-                        rootName = objName;
-                    }
-                    else if (slashIndex == 0 || slashIndex == objName.Length - 1)
-                    {
-                        Logger.APILogger.LogWarn(
-                            $"Invalid preload object name given by mod `{mod.Mod.GetName()}`: \"{objName}\""
-                        );
-                        continue;
-                    }
-                    else
-                    {
-                        rootName = objName.Substring(0, slashIndex);
-                        childName = objName.Substring(slashIndex + 1);
-                    }
-
-                    // Get root object
-                    GameObject obj = rootObjects.FirstOrDefault(o => o.name == rootName);
+                    GameObject obj = UnityExtensions.GetGameObjectFromArray(rootObjects, objName);
                     if (obj == null)
                     {
                         Logger.APILogger.LogWarn(
                             $"Could not find object \"{objName}\" in scene \"{sceneName}\"," + $" requested by mod `{mod.Mod.GetName()}`"
                         );
                         continue;
-                    }
-
-                    // Get child object
-                    if (childName != null)
-                    {
-                        Transform t = obj.transform.Find(childName);
-                        if (t == null)
-                        {
-                            Logger.APILogger.LogWarn(
-                                $"Could not find object \"{objName}\" in scene \"{sceneName}\"," + $" requested by mod `{mod.Mod.GetName()}`"
-                            );
-                            continue;
-                        }
-
-                        obj = t.gameObject;
                     }
 
                     // Create all sub-dictionaries if necessary (Yes, it's terrible)

--- a/Assembly-CSharp/Utils/AssemblyExtensions.cs
+++ b/Assembly-CSharp/Utils/AssemblyExtensions.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Modding
+namespace Modding.Utils
 {
     /// <summary>
-    /// Class containing extensions used by the Modding API for dealing with assemblies.
+    /// Class containing extensions used by the Modding API for interacting with assemblies.
     /// </summary>
     public static class AssemblyExtensions
     {

--- a/Assembly-CSharp/Utils/UnityExtensions.cs
+++ b/Assembly-CSharp/Utils/UnityExtensions.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Modding.Utils
+{
+    /// <summary>
+    /// Class containing extensions used by the Modding API for interacting with Unity types.
+    /// </summary>
+    public static class UnityExtensions
+    {
+        /// <summary>
+        /// Get the component of type T attached to GameObject go. If go does not have such a component, add
+        /// that component (and return it).
+        /// </summary>
+        public static T GetOrAddComponent<T>(this GameObject go) where T : Component
+        {
+            T component = go.GetComponent<T>();
+            if (component == null)
+            {
+                component = go.AddComponent<T>();
+            }
+            return component;
+        }
+
+        /// <summary>
+        /// Find a game object by name in the scene. The object's name must be given in the hierarchy.
+        /// </summary>
+        /// <param name="scene">The scene to search.</param>
+        /// <param name="objName">The name of the object in the hierarchy, with '/' separating parent GameObjects from child GameObjects.</param>
+        /// <returns>The GameObject if found; null if not.</returns>
+        public static GameObject FindGameObject(this Scene scene, string objName)
+        {
+            GameObject[] rootObjects = scene.GetRootGameObjects();
+            return GetGameObjectFromArray(rootObjects, objName);
+        }
+
+        internal static GameObject GetGameObjectFromArray(GameObject[] objects, string objName)
+        {
+            // Split object name into root and child names based on '/'
+            string rootName;
+            string childName = null;
+
+            int slashIndex = objName.IndexOf('/');
+            if (slashIndex == -1)
+            {
+                rootName = objName;
+            }
+            else if (slashIndex == 0 || slashIndex == objName.Length - 1)
+            {
+                Logger.APILogger.LogWarn($"Invalid GameObject name {objName}");
+                return null;
+            }
+            else
+            {
+                rootName = objName.Substring(0, slashIndex);
+                childName = objName.Substring(slashIndex + 1);
+            }
+
+            // Get root object
+            GameObject obj = objects.FirstOrDefault(o => o.name == rootName);
+            if (obj == null)
+            {
+                return null;
+            }
+
+            // Get child object
+            if (childName != null)
+            {
+                Transform t = obj.transform.Find(childName);
+                if (t == null)
+                {
+                    return null;
+                }
+
+                obj = t.gameObject;
+            }
+
+            return obj;
+        }
+    }
+}

--- a/Assembly-CSharp/Utils/UnityExtensions.cs
+++ b/Assembly-CSharp/Utils/UnityExtensions.cs
@@ -31,6 +31,7 @@ namespace Modding.Utils
         /// <param name="scene">The scene to search.</param>
         /// <param name="objName">The name of the object in the hierarchy, with '/' separating parent GameObjects from child GameObjects.</param>
         /// <returns>The GameObject if found; null if not.</returns>
+        /// <exception cref="ArgumentException">Thrown if the path to the game object is invalid.</exception>
         public static GameObject FindGameObject(this Scene scene, string objName)
         {
             GameObject[] rootObjects = scene.GetRootGameObjects();
@@ -50,8 +51,7 @@ namespace Modding.Utils
             }
             else if (slashIndex == 0 || slashIndex == objName.Length - 1)
             {
-                Logger.APILogger.LogWarn($"Invalid GameObject name {objName}");
-                return null;
+                throw new ArgumentException("Invalid GameObject path");
             }
             else
             {
@@ -61,21 +61,13 @@ namespace Modding.Utils
 
             // Get root object
             GameObject obj = objects.FirstOrDefault(o => o.name == rootName);
-            if (obj == null)
-            {
-                return null;
-            }
+            if (obj == null) return null;
 
             // Get child object
             if (childName != null)
             {
                 Transform t = obj.transform.Find(childName);
-                if (t == null)
-                {
-                    return null;
-                }
-
-                obj = t.gameObject;
+                return t == null ? null : t.gameObject;
             }
 
             return obj;


### PR DESCRIPTION
Both of the methods in UnityExtensions are used all the time in mods, so it seems good to make them publically available in the MAPI.

Move extensions to the `Modding.Utils` namespace