### PR TITLE
Better guard against second mod load

### DIFF
--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -2206,7 +2206,7 @@ namespace Modding
             add
             {
                 _finishedLoadingModsHook += value;
-                if (ModLoader.Loaded)
+                if (ModLoader.LoadState.HasFlag(ModLoader.ModLoadState.Loaded))
                 {
                     try
                     {

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -57,6 +57,8 @@ namespace Modding
         {
             if (Loaded || Preloaded)
             {
+                if (Preloaded) Logger.APILogger.LogDebug("Already preloaded mods");
+                if (Loaded) Logger.APILogger.LogDebug("Already loaded mods");
                 UObject.Destroy(coroutineHolder);
                 yield break;
             }

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -32,18 +32,7 @@ namespace Modding
             Loaded = 4,
         }
 
-        public static ModLoadState modLoadState = ModLoadState.NotStarted;
-
-        /// <summary>
-        ///     Checks if the mod loads are done.
-        /// </summary>
-        public static bool Loaded => modLoadState.HasFlag(ModLoadState.Loaded);
-
-        /// <summary>
-        ///     Checks if the mod preloads are done
-        /// </summary>
-        public static bool Preloaded => modLoadState.HasFlag(ModLoadState.Preloaded);
-
+        public static ModLoadState LoadState = ModLoadState.NotStarted;
 
 
         public static Dictionary<Type, ModInstance> ModInstanceTypeMap { get; private set; } = new();
@@ -68,14 +57,6 @@ namespace Modding
         /// <returns></returns>
         public static IEnumerator LoadModsInit(GameObject coroutineHolder)
         {
-            if (Loaded || Preloaded)
-            {
-                // Not expected
-                Logger.APILogger.LogWarn($"LoadModsInit: Already begun loading mods (state {modLoadState})");
-                UObject.Destroy(coroutineHolder);
-                yield break;
-            }
-
             Logger.APILogger.Log("Starting mod loading");
 
             string managed_path = SystemInfo.operatingSystemFamily switch
@@ -91,7 +72,7 @@ namespace Modding
 
             if (managed_path is null)
             {
-                modLoadState |= ModLoadState.Loaded;
+                LoadState |= ModLoadState.Loaded;
 
                 UObject.Destroy(coroutineHolder);
 
@@ -260,7 +241,7 @@ namespace Modding
             Logger.APILogger.Log("Finished loading mods:\n" + modVersionDraw.drawString);
 
             ModHooks.OnFinishedLoadingMods();
-            modLoadState |= ModLoadState.Loaded;
+            LoadState |= ModLoadState.Loaded;
 
             new ModListMenu().InitMenuCreation();
 

--- a/Assembly-CSharp/Patches/ObjectPool.cs
+++ b/Assembly-CSharp/Patches/ObjectPool.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using MonoMod;
 using UnityEngine;
 
@@ -25,7 +25,7 @@ namespace Modding.Patches
                 GameObject obj = orig_Spawn(prefab, parent, position, rotation);
                 return ModHooks.OnObjectPoolSpawn(obj);
             }
-            catch (NullReferenceException) when (!ModLoader.Preloaded)
+            catch (NullReferenceException) when (!ModLoader.LoadState.HasFlag(ModLoader.ModLoadState.Preloaded))
             {
                 return null;
             }
@@ -38,7 +38,7 @@ namespace Modding.Patches
             {
                 orig_CreatePool(prefab, initialPoolSize);
             }
-            catch (NullReferenceException) when (!ModLoader.Preloaded)
+            catch (NullReferenceException) when (!ModLoader.LoadState.HasFlag(ModLoader.ModLoadState.Preloaded))
             { }
         }
     }

--- a/Assembly-CSharp/Patches/OnScreenDebugInfo.cs
+++ b/Assembly-CSharp/Patches/OnScreenDebugInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using MonoMod;
 using UnityEngine;
 
@@ -12,18 +12,28 @@ namespace Modding.Patches
     {
         private extern void orig_Awake();
 
+        private static bool StartedModLoading;
+
         private void Awake()
         {
-            Logger.APILogger.Log("Main menu loading");
+            if (!StartedModLoading)
+            {
+                Logger.APILogger.Log("Main menu loading");
+                StartedModLoading = true;
 
-            GameObject obj = new GameObject();
-            DontDestroyOnLoad(obj);
+                GameObject obj = new GameObject();
+                DontDestroyOnLoad(obj);
 
-            // Preload reflection
-            new Thread(ReflectionHelper.PreloadCommonTypes).Start();
+                // Preload reflection
+                new Thread(ReflectionHelper.PreloadCommonTypes).Start();
 
-            // NonBouncer does absolutely nothing, which makes it a good dummy to run the loader
-            obj.AddComponent<NonBouncer>().StartCoroutine(ModLoader.LoadModsInit(obj));
+                // NonBouncer does absolutely nothing, which makes it a good dummy to run the loader
+                obj.AddComponent<NonBouncer>().StartCoroutine(ModLoader.LoadModsInit(obj));
+            }
+            else
+            {
+                Logger.APILogger.LogDebug("Already begun mod loading");
+            }
 
             orig_Awake();
         }

--- a/Assembly-CSharp/Patches/OnScreenDebugInfo.cs
+++ b/Assembly-CSharp/Patches/OnScreenDebugInfo.cs
@@ -12,14 +12,12 @@ namespace Modding.Patches
     {
         private extern void orig_Awake();
 
-        private static bool StartedModLoading;
-
         private void Awake()
         {
-            if (!StartedModLoading)
+            if (ModLoader.modLoadState == ModLoader.ModLoadState.NotStarted)
             {
                 Logger.APILogger.Log("Main menu loading");
-                StartedModLoading = true;
+                ModLoader.modLoadState = ModLoader.ModLoadState.Started;
 
                 GameObject obj = new GameObject();
                 DontDestroyOnLoad(obj);
@@ -32,7 +30,8 @@ namespace Modding.Patches
             }
             else
             {
-                Logger.APILogger.LogDebug("Already begun mod loading");
+                // Debug log because this is the expected code path
+                Logger.APILogger.LogDebug($"OnScreenDebugInfo: Already begun mod loading (state {ModLoader.modLoadState})");
             }
 
             orig_Awake();

--- a/Assembly-CSharp/Patches/OnScreenDebugInfo.cs
+++ b/Assembly-CSharp/Patches/OnScreenDebugInfo.cs
@@ -14,10 +14,10 @@ namespace Modding.Patches
 
         private void Awake()
         {
-            if (ModLoader.modLoadState == ModLoader.ModLoadState.NotStarted)
+            if (ModLoader.LoadState == ModLoader.ModLoadState.NotStarted)
             {
                 Logger.APILogger.Log("Main menu loading");
-                ModLoader.modLoadState = ModLoader.ModLoadState.Started;
+                ModLoader.LoadState = ModLoader.ModLoadState.Started;
 
                 GameObject obj = new GameObject();
                 DontDestroyOnLoad(obj);
@@ -31,7 +31,7 @@ namespace Modding.Patches
             else
             {
                 // Debug log because this is the expected code path
-                Logger.APILogger.LogDebug($"OnScreenDebugInfo: Already begun mod loading (state {ModLoader.modLoadState})");
+                Logger.APILogger.LogDebug($"OnScreenDebugInfo: Already begun mod loading (state {ModLoader.LoadState})");
             }
 
             orig_Awake();

--- a/Assembly-CSharp/Patches/SceneManager.cs
+++ b/Assembly-CSharp/Patches/SceneManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using MonoMod;
@@ -75,7 +75,7 @@ namespace Modding.Patches
             {
                 orig_Start();
             }
-            catch (NullReferenceException) when (!ModLoader.Preloaded)
+            catch (NullReferenceException) when (!ModLoader.LoadState.HasFlag(ModLoader.ModLoadState.Preloaded))
             { }
         }
     }

--- a/Assembly-CSharp/Preloader.cs
+++ b/Assembly-CSharp/Preloader.cs
@@ -287,7 +287,7 @@ internal class Preloader : MonoBehaviour
         // Reload the main menu to fix the music/shaders
         Logger.APILogger.LogDebug("Preload done, returning to main menu");
 
-        ModLoader.modLoadState |= ModLoader.ModLoadState.Preloaded;
+        ModLoader.LoadState |= ModLoader.ModLoadState.Preloaded;
 
         yield return USceneManager.LoadSceneAsync("Quit_To_Menu");
 

--- a/Assembly-CSharp/Preloader.cs
+++ b/Assembly-CSharp/Preloader.cs
@@ -287,7 +287,7 @@ internal class Preloader : MonoBehaviour
         // Reload the main menu to fix the music/shaders
         Logger.APILogger.LogDebug("Preload done, returning to main menu");
 
-        ModLoader.Preloaded = true;
+        ModLoader.modLoadState |= ModLoader.ModLoadState.Preloaded;
 
         yield return USceneManager.LoadSceneAsync("Quit_To_Menu");
 


### PR DESCRIPTION
It seems that people have been getting a bug where the second OnScreenDebugInfo awakes before preloading is finished, so the LoadModsInit coroutine is started a second time. This guards against that.