### PR TITLE
Never load null global settings

### DIFF
--- a/Assembly-CSharp/Mod.cs
+++ b/Assembly-CSharp/Mod.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using JetBrains.Annotations;
@@ -202,6 +202,11 @@ namespace Modding
                             Converters = JsonConverterTypes.ConverterTypes
                         }
                     );
+                    if (obj is null)
+                    {
+                        Logger.APILogger.LogError($"Null global settings passed to {GetName()}");
+                        return;
+                    }
                     this.onLoadGlobalSettings(this, obj);
                 }
             }


### PR DESCRIPTION
I don't know how exactly users manage to get their global settings to be null but it happens fairly often in #modding-help and I believe it should not be mods' responsibility to guard against the MAPI giving them null.