### PR TITLE
Enforce no mods with the same name

### DIFF
--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -223,6 +223,7 @@ namespace Modding
             {
                 if (mod.Error is not null)
                 {
+                    Logger.APILogger.LogWarn($"Not loading mod {mod.Name}: error state {mod.Error}");
                     continue;
                 }
 
@@ -274,7 +275,6 @@ namespace Modding
             {
                 if (mod.Error != null)
                 {
-                    Logger.APILogger.LogWarn($"Not loading mod {mod.Name}: error state {mod.Error}");
                     continue;
                 }
 

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -41,12 +41,14 @@ namespace Modding
 
         private static void AddModInstance(Type ty, ModInstance mod)
         {
-            if (ModInstanceNameMap.ContainsKey(ty.Name))
+            if (ModInstanceNameMap.ContainsKey(mod.Name))
             {
+                Logger.APILogger.LogWarn($"Found multiple mods with name {mod.Name}.");
                 mod.Error = ModErrorState.Duplicate;
-                ModInstanceNameMap[ty.Name].Error = ModErrorState.Duplicate;
+                ModInstanceNameMap[mod.Name].Error = ModErrorState.Duplicate;
                 ModInstanceTypeMap[ty] = mod;
                 ModInstances.Add(mod);
+                return;
             }
 
             ModInstanceTypeMap[ty] = mod;
@@ -155,7 +157,7 @@ namespace Modding
 
                         try
                         {
-                            if (ty.GetConstructor(new Type[0])?.Invoke(new object[0]) is Mod mod)
+                            if (ty.GetConstructor(Type.EmptyTypes)?.Invoke(Array.Empty<object>()) is Mod mod)
                             {
                                 AddModInstance(
                                     ty,

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -274,6 +274,7 @@ namespace Modding
             {
                 if (mod.Error != null)
                 {
+                    Logger.APILogger.LogWarn($"Not loading mod {mod.Name}: error state {mod.Error}");
                     continue;
                 }
 

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -41,6 +41,14 @@ namespace Modding
 
         private static void AddModInstance(Type ty, ModInstance mod)
         {
+            if (ModInstanceNameMap.ContainsKey(ty.Name))
+            {
+                mod.Error = ModErrorState.Duplicate;
+                ModInstanceNameMap[ty.Name].Error = ModErrorState.Duplicate;
+                ModInstanceTypeMap[ty] = mod;
+                ModInstances.Add(mod);
+            }
+
             ModInstanceTypeMap[ty] = mod;
             ModInstanceNameMap[mod.Name] = mod;
             ModInstances.Add(mod);
@@ -211,6 +219,11 @@ namespace Modding
 
             foreach (ModInstance mod in orderedMods)
             {
+                if (mod.Error is not null)
+                {
+                    continue;
+                }
+
                 try
                 {
                     preloadedObjects.TryGetValue(mod, out Dictionary<string, Dictionary<string, GameObject>> preloads);
@@ -339,6 +352,9 @@ namespace Modding
                         case ModErrorState.Construct:
                             builder.AppendLine($"{mod.Name} : Failed to call constructor! Check ModLog.txt");
                             break;
+                        case ModErrorState.Duplicate:
+                            builder.AppendLine($"{mod.Name} : Failed to load! Duplicate mod detected");
+                            break;
                         case ModErrorState.Initialize:
                             builder.AppendLine($"{mod.Name} : Failed to initialize! Check ModLog.txt");
                             break;
@@ -415,6 +431,7 @@ namespace Modding
         public enum ModErrorState
         {
             Construct,
+            Duplicate,
             Initialize,
             Unload
         }

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -39,7 +39,13 @@ namespace Modding
         public static Dictionary<string, ModInstance> ModInstanceNameMap { get; private set; } = new();
         public static HashSet<ModInstance> ModInstances { get; private set; } = new();
 
-        private static void AddModInstance(Type ty, ModInstance mod)
+        /// <summary>
+        /// Try to add a ModInstance to the internal dictionaries.
+        /// </summary>
+        /// <param name="ty">The type of the mod.</param>
+        /// <param name="mod">The ModInstance.</param>
+        /// <returns>True if the ModInstance was successfully added; false otherwise.</returns>
+        private static bool TryAddModInstance(Type ty, ModInstance mod)
         {
             if (ModInstanceNameMap.ContainsKey(mod.Name))
             {
@@ -48,12 +54,13 @@ namespace Modding
                 ModInstanceNameMap[mod.Name].Error = ModErrorState.Duplicate;
                 ModInstanceTypeMap[ty] = mod;
                 ModInstances.Add(mod);
-                return;
+                return false;
             }
 
             ModInstanceTypeMap[ty] = mod;
             ModInstanceNameMap[mod.Name] = mod;
             ModInstances.Add(mod);
+            return true;
         }
 
         private static ModVersionDraw modVersionDraw;
@@ -159,7 +166,7 @@ namespace Modding
                         {
                             if (ty.GetConstructor(Type.EmptyTypes)?.Invoke(Array.Empty<object>()) is Mod mod)
                             {
-                                AddModInstance(
+                                TryAddModInstance(
                                     ty,
                                     new ModInstance
                                     {
@@ -175,7 +182,7 @@ namespace Modding
                         {
                             Logger.APILogger.LogError(e);
 
-                            AddModInstance(
+                            TryAddModInstance(
                                 ty,
                                 new ModInstance
                                 {


### PR DESCRIPTION
Typically this issue arises if the user manually installed a mod and then installed it with Scarab or something like that. In such cases it's uniformly an error (sometimes without significant effect) so I feel like refusing to load such mods in that case is correct.