### PR TITLE
Replace remaining PlayerData field accesses with GetBool etc

### DIFF
--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -252,7 +252,7 @@ namespace Modding
         /// <summary>
         ///     Called whenever game tries to show cursor
         /// </summary>
-        internal static void OnCursor()
+        internal static void OnCursor(GameManager gm)
         {
             Cursor.lockState = CursorLockMode.None;
 
@@ -262,7 +262,7 @@ namespace Modding
                 return;
             }
 
-            if (GameManager.instance.isPaused)
+            if (gm.isPaused)
             {
                 Cursor.visible = true;
                 return;
@@ -621,7 +621,8 @@ namespace Modding
         /// </summary>
         /// <param name="target">Target Field Name</param>
         /// <param name="orig">Value to set</param>
-        internal static void SetPlayerBool(string target, bool orig)
+        /// <param name="pd">The PlayerData object</param>
+        internal static void SetPlayerBool(string target, bool orig, Patches.PlayerData pd)
         {
             bool value = orig;
 
@@ -642,7 +643,7 @@ namespace Modding
                 }
             }
 
-            Patches.PlayerData.instance.SetBoolInternal(target, value);
+            pd.SetBoolInternal(target, value);
         }
 
 
@@ -668,9 +669,10 @@ namespace Modding
         ///     Called by the game in PlayerData.GetBool
         /// </summary>
         /// <param name="target">Target Field Name</param>
-        internal static bool GetPlayerBool(string target)
+        /// <param name="pd">The PlayerData object</param>
+        internal static bool GetPlayerBool(string target, Patches.PlayerData pd)
         {
-            bool result = Patches.PlayerData.instance.GetBoolInternal(target);
+            bool result = pd.GetBoolInternal(target);
 
             if (GetPlayerBoolHook == null)
                 return result;
@@ -724,7 +726,8 @@ namespace Modding
         /// </summary>
         /// <param name="target">Target Field Name</param>
         /// <param name="orig">Value to set</param>
-        internal static void SetPlayerInt(string target, int orig)
+        /// <param name="pd">The PlayerData object</param>
+        internal static void SetPlayerInt(string target, int orig, Patches.PlayerData pd)
         {
             int value = orig;
 
@@ -745,7 +748,7 @@ namespace Modding
                 }
             }
 
-            Patches.PlayerData.instance.SetIntInternal(target, value);
+            pd.SetIntInternal(target, value);
         }
 
         /// <summary>
@@ -772,9 +775,10 @@ namespace Modding
         ///     Called by the game in PlayerData.GetInt
         /// </summary>
         /// <param name="target">Target Field Name</param>
-        internal static int GetPlayerInt(string target)
+        /// <param name="pd">The PlayerData object</param>
+        internal static int GetPlayerInt(string target, Patches.PlayerData pd)
         {
-            int result = Patches.PlayerData.instance.GetIntInternal(target);
+            int result = pd.GetIntInternal(target);
 
             if (GetPlayerIntHook == null)
                 return result;
@@ -808,7 +812,8 @@ namespace Modding
         /// </summary>
         /// <param name="target">Target Field Name</param>
         /// <param name="orig">Value to set</param>
-        internal static void SetPlayerFloat(string target, float orig)
+        /// <param name="pd">The PlayerData object</param>
+        internal static void SetPlayerFloat(string target, float orig, Patches.PlayerData pd)
         {
             float value = orig;
 
@@ -829,7 +834,7 @@ namespace Modding
                 }
             }
 
-            Patches.PlayerData.instance.SetFloatInternal(target, value);
+            pd.SetFloatInternal(target, value);
         }
 
         /// <summary>
@@ -843,9 +848,10 @@ namespace Modding
         ///     Called by the game in PlayerData.GetFloat
         /// </summary>
         /// <param name="target">Target Field Name</param>
-        internal static float GetPlayerFloat(string target)
+        /// <param name="pd">The PlayerData object</param>
+        internal static float GetPlayerFloat(string target, Patches.PlayerData pd)
         {
-            float result = Patches.PlayerData.instance.GetFloatInternal(target);
+            float result = pd.GetFloatInternal(target);
 
             if (GetPlayerFloatHook == null)
                 return result;
@@ -879,7 +885,8 @@ namespace Modding
         /// </summary>
         /// <param name="target">Target Field Name</param>
         /// <param name="orig">Value to set</param>
-        internal static void SetPlayerString(string target, string orig)
+        /// <param name="pd">The PlayerData object</param>
+        internal static void SetPlayerString(string target, string orig, Patches.PlayerData pd)
         {
             string value = orig;
 
@@ -900,7 +907,7 @@ namespace Modding
                 }
             }
 
-            Patches.PlayerData.instance.SetStringInternal(target, value);
+            pd.SetStringInternal(target, value);
         }
 
         /// <summary>
@@ -914,9 +921,10 @@ namespace Modding
         ///     Called by the game in PlayerData.GetString
         /// </summary>
         /// <param name="target">Target Field Name</param>
-        internal static string GetPlayerString(string target)
+        /// <param name="pd">The PlayerData object</param>
+        internal static string GetPlayerString(string target, Patches.PlayerData pd)
         {
-            string value = Patches.PlayerData.instance.GetStringInternal(target);
+            string value = pd.GetStringInternal(target);
 
             if (GetPlayerStringHook == null)
                 return value;
@@ -950,7 +958,8 @@ namespace Modding
         /// </summary>
         /// <param name="target">Target Field Name</param>
         /// <param name="orig">Value to set</param>
-        internal static void SetPlayerVector3(string target, Vector3 orig)
+        /// <param name="pd">The PlayerData object</param>
+        internal static void SetPlayerVector3(string target, Vector3 orig, Patches.PlayerData pd)
         {
             Vector3 value = orig;
 
@@ -971,7 +980,7 @@ namespace Modding
                 }
             }
 
-            Patches.PlayerData.instance.SetVector3Internal(target, value);
+            pd.SetVector3Internal(target, value);
         }
 
         /// <summary>
@@ -985,9 +994,10 @@ namespace Modding
         ///     Called by the game in PlayerData.GetVector3
         /// </summary>
         /// <param name="target">Target Field Name</param>
-        internal static Vector3 GetPlayerVector3(string target)
+        /// <param name="pd">The PlayerData object</param>
+        internal static Vector3 GetPlayerVector3(string target, Patches.PlayerData pd)
         {
-            Vector3 res = Patches.PlayerData.instance.GetVector3Internal(target);
+            Vector3 res = pd.GetVector3Internal(target);
 
             if (GetPlayerVector3Hook == null)
                 return res;
@@ -1021,37 +1031,38 @@ namespace Modding
         /// </summary>
         /// <param name="target">Target Field Name</param>
         /// <param name="orig">Value to set</param>
-        internal static void SetPlayerVariable<T>(string target, T orig)
+        /// <param name="pd">The PlayerData object</param>
+        internal static void SetPlayerVariable<T>(string target, T orig, Patches.PlayerData pd)
         {
             Type t = typeof(T);
 
             if (t == typeof(bool))
             {
-                SetPlayerBool(target, (bool)(object)orig);
+                SetPlayerBool(target, (bool)(object)orig, pd);
                 return;
             }
 
             if (t == typeof(int))
             {
-                SetPlayerInt(target, (int)(object)orig);
+                SetPlayerInt(target, (int)(object)orig, pd);
                 return;
             }
 
             if (t == typeof(float))
             {
-                SetPlayerFloat(target, (float)(object)orig);
+                SetPlayerFloat(target, (float)(object)orig, pd);
                 return;
             }
 
             if (t == typeof(string))
             {
-                SetPlayerString(target, (string)(object)orig);
+                SetPlayerString(target, (string)(object)orig, pd);
                 return;
             }
 
             if (t == typeof(Vector3))
             {
-                SetPlayerVector3(target, (Vector3)(object)orig);
+                SetPlayerVector3(target, (Vector3)(object)orig, pd);
                 return;
             }
 
@@ -1074,7 +1085,7 @@ namespace Modding
                 }
             }
 
-            Patches.PlayerData.instance.SetVariableInternal(target, value);
+            pd.SetVariableInternal(target, value);
         }
 
         /// <summary>
@@ -1089,36 +1100,37 @@ namespace Modding
         ///     Called by the game in PlayerData.GetVariable
         /// </summary>
         /// <param name="target">Target Field Name</param>
-        internal static T GetPlayerVariable<T>(string target)
+        /// <param name="pd">The PlayerData object</param>
+        internal static T GetPlayerVariable<T>(string target, Patches.PlayerData pd)
         {
             Type t = typeof(T);
 
             if (t == typeof(bool))
             {
-                return (T)(object)GetPlayerBool(target);
+                return (T)(object)GetPlayerBool(target, pd);
             }
 
             if (t == typeof(int))
             {
-                return (T)(object)GetPlayerInt(target);
+                return (T)(object)GetPlayerInt(target, pd);
             }
 
             if (t == typeof(float))
             {
-                return (T)(object)GetPlayerFloat(target);
+                return (T)(object)GetPlayerFloat(target, pd);
             }
 
             if (t == typeof(string))
             {
-                return (T)(object)GetPlayerString(target);
+                return (T)(object)GetPlayerString(target, pd);
             }
 
             if (t == typeof(Vector3))
             {
-                return (T)(object)GetPlayerVector3(target);
+                return (T)(object)GetPlayerVector3(target, pd);
             }
 
-            T value = Patches.PlayerData.instance.GetVariableInternal<T>(target);
+            T value = pd.GetVariableInternal<T>(target);
 
             if (GetPlayerVariableHook == null)
                 return value;
@@ -1503,7 +1515,7 @@ namespace Modding
         ///     Called after player values for charms have been set
         /// </summary>
         /// <remarks>HeroController.CharmUpdate</remarks>
-        internal static void OnCharmUpdate()
+        internal static void OnCharmUpdate(PlayerData pd, Patches.HeroController hc)
         {
             Logger.APILogger.LogFine("OnCharmUpdate Invoked");
 
@@ -1518,7 +1530,7 @@ namespace Modding
             {
                 try
                 {
-                    toInvoke.Invoke(PlayerData.instance, HeroController.instance);
+                    toInvoke.Invoke(pd, hc);
                 }
                 catch (Exception ex)
                 {

--- a/Assembly-CSharp/Patches/GameManager.cs
+++ b/Assembly-CSharp/Patches/GameManager.cs
@@ -128,10 +128,10 @@ namespace Modding.Patches
 
                     if (this.playerData != null)
                     {
-                        this.playerData.playTime += this.sessionPlayTimer;
+                        this.playerData.SetFloat(nameof(PlayerData.playTime), this.playerData.GetFloat(nameof(PlayerData.playTime)) + this.sessionPlayTimer);
                         this.ResetGameTimer();
-                        this.playerData.version = Constants.GAME_VERSION;
-                        this.playerData.profileID = saveSlot;
+                        this.playerData.SetString(nameof(PlayerData.version), Constants.GAME_VERSION);
+                        this.playerData.SetInt(nameof(PlayerData.profileID), saveSlot);
                         this.playerData.CountGameCompletion();
                     }
                     else

--- a/Assembly-CSharp/Patches/GameManager.cs
+++ b/Assembly-CSharp/Patches/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -500,15 +500,15 @@ namespace Modding.Patches
                         global::PlayerData playerData = saveGameData.playerData;
                         SaveStats saveStats = new SaveStats
                         (
-                            playerData.maxHealthBase,
-                            playerData.geo,
-                            playerData.mapZone,
-                            playerData.playTime,
-                            playerData.MPReserveMax,
-                            playerData.permadeathMode,
-                            playerData.bossRushMode,
-                            playerData.completionPercentage,
-                            playerData.unlockedCompletionRate
+                            playerData.GetInt(nameof(PlayerData.maxHealthBase)),
+                            playerData.GetInt(nameof(PlayerData.geo)),
+                            playerData.GetVariable<GlobalEnums.MapZone>(nameof(PlayerData.mapZone)),
+                            playerData.GetFloat(nameof(PlayerData.playTime)),
+                            playerData.GetInt(nameof(PlayerData.MPReserveMax)),
+                            playerData.GetInt(nameof(PlayerData.permadeathMode)),
+                            playerData.GetBool(nameof(PlayerData.bossRushMode)),
+                            playerData.GetFloat(nameof(PlayerData.completionPercentage)),
+                            playerData.GetBool(nameof(PlayerData.unlockedCompletionRate))
                         );
                         if (callback != null)
                         {
@@ -633,7 +633,7 @@ namespace Modding.Patches
         {
             if (!this.TimeSlowed)
             {
-                if (!this.playerData.disablePause && this.gameState == GlobalEnums.GameState.PLAYING)
+                if (!this.playerData.GetBool(nameof(PlayerData.disablePause)) && this.gameState == GlobalEnums.GameState.PLAYING)
                 {
                     this.gameCams.StopCameraShake();
                     this.inputHandler.PreventPause();

--- a/Assembly-CSharp/Patches/HeroController.cs
+++ b/Assembly-CSharp/Patches/HeroController.cs
@@ -921,7 +921,7 @@ namespace Modding.Patches
         public void CharmUpdate()
         {
             orig_CharmUpdate();
-            ModHooks.OnCharmUpdate();
+            ModHooks.OnCharmUpdate(playerData, this);
             playerData.UpdateBlueHealth();
         }
 

--- a/Assembly-CSharp/Patches/HeroController.cs
+++ b/Assembly-CSharp/Patches/HeroController.cs
@@ -59,7 +59,7 @@ namespace Modding.Patches
             }
 
             this.cState.attacking = true;
-            if (this.playerData.equippedCharm_32)
+            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_32)))
             {
                 this.attackDuration = this.ATTACK_DURATION_CH;
             }
@@ -92,9 +92,9 @@ namespace Modding.Patches
                         this.cState.altAttack = false;
                     }
 
-                    if (this.playerData.equippedCharm_35)
+                    if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_35)))
                     {
-                        if ((this.playerData.health == this.playerData.maxHealth && !this.playerData.equippedCharm_27) || (this.joniBeam && this.playerData.equippedCharm_27))
+                        if ((this.playerData.GetInt(nameof(PlayerData.health)) == this.playerData.GetInt(nameof(PlayerData.maxHealth)) && !this.playerData.GetBool(nameof(PlayerData.equippedCharm_27))) || (this.joniBeam && this.playerData.GetBool(nameof(PlayerData.equippedCharm_27))))
                         {
                             if (this.transform.localScale.x < 0f)
                             {
@@ -105,7 +105,7 @@ namespace Modding.Patches
                                 this.grubberFlyBeam = this.grubberFlyBeamPrefabL.Spawn(this.transform.position);
                             }
 
-                            if (this.playerData.equippedCharm_13)
+                            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_13)))
                             {
                                 this.grubberFlyBeam.transform.SetScaleY(this.MANTIS_CHARM_SCALE);
                             }
@@ -115,7 +115,7 @@ namespace Modding.Patches
                             }
                         }
 
-                        if (this.playerData.health == 1 && this.playerData.equippedCharm_6 && this.playerData.healthBlue < 1)
+                        if (this.playerData.GetInt(nameof(PlayerData.health)) == 1 && this.playerData.GetBool(nameof(PlayerData.equippedCharm_6)) && this.playerData.GetInt(nameof(PlayerData.healthBlue)) < 1)
                         {
                             if (this.transform.localScale.x < 0f)
                             {
@@ -126,7 +126,7 @@ namespace Modding.Patches
                                 this.grubberFlyBeam = this.grubberFlyBeamPrefabL_fury.Spawn(this.transform.position);
                             }
 
-                            if (this.playerData.equippedCharm_13)
+                            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_13)))
                             {
                                 this.grubberFlyBeam.transform.SetScaleY(this.MANTIS_CHARM_SCALE);
                             }
@@ -142,25 +142,25 @@ namespace Modding.Patches
                     this.slashComponent = this.upSlash;
                     this.slashFsm = this.upSlashFsm;
                     this.cState.upAttacking = true;
-                    if (this.playerData.equippedCharm_35)
+                    if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_35)))
                     {
-                        if ((this.playerData.health == this.playerData.maxHealth && !this.playerData.equippedCharm_27) || (this.joniBeam && this.playerData.equippedCharm_27))
+                        if ((this.playerData.GetInt(nameof(PlayerData.health)) == this.playerData.GetInt(nameof(PlayerData.maxHealth)) && !this.playerData.GetBool(nameof(PlayerData.equippedCharm_27))) || (this.joniBeam && this.playerData.GetBool(nameof(PlayerData.equippedCharm_27))))
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabU.Spawn(this.transform.position);
                             this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 270f);
-                            if (this.playerData.equippedCharm_13)
+                            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_13)))
                             {
                                 this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
                         }
 
-                        if (this.playerData.health == 1 && this.playerData.equippedCharm_6 && this.playerData.healthBlue < 1)
+                        if (this.playerData.GetInt(nameof(PlayerData.health)) == 1 && this.playerData.GetBool(nameof(PlayerData.equippedCharm_6)) && this.playerData.GetInt(nameof(PlayerData.healthBlue)) < 1)
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabU_fury.Spawn(this.transform.position);
                             this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 270f);
-                            if (this.playerData.equippedCharm_13)
+                            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_13)))
                             {
                                 this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
@@ -172,25 +172,25 @@ namespace Modding.Patches
                     this.slashComponent = this.downSlash;
                     this.slashFsm = this.downSlashFsm;
                     this.cState.downAttacking = true;
-                    if (this.playerData.equippedCharm_35)
+                    if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_35)))
                     {
-                        if ((this.playerData.health == this.playerData.maxHealth && !this.playerData.equippedCharm_27) || (this.joniBeam && this.playerData.equippedCharm_27))
+                        if ((this.playerData.GetInt(nameof(PlayerData.health)) == this.playerData.GetInt(nameof(PlayerData.maxHealth)) && !this.playerData.GetBool(nameof(PlayerData.equippedCharm_27))) || (this.joniBeam && this.playerData.GetBool(nameof(PlayerData.equippedCharm_27))))
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabD.Spawn(this.transform.position);
                             this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 90f);
-                            if (this.playerData.equippedCharm_13)
+                            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_13)))
                             {
                                 this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
                         }
 
-                        if (this.playerData.health == 1 && this.playerData.equippedCharm_6 && this.playerData.healthBlue < 1)
+                        if (this.playerData.GetInt(nameof(PlayerData.health)) == 1 && this.playerData.GetBool(nameof(PlayerData.equippedCharm_6)) && this.playerData.GetInt(nameof(PlayerData.healthBlue)) < 1)
                         {
                             this.grubberFlyBeam = this.grubberFlyBeamPrefabD_fury.Spawn(this.transform.position);
                             this.grubberFlyBeam.transform.SetScaleY(this.transform.localScale.x);
                             this.grubberFlyBeam.transform.localEulerAngles = new Vector3(0f, 0f, 90f);
-                            if (this.playerData.equippedCharm_13)
+                            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_13)))
                             {
                                 this.grubberFlyBeam.transform.SetScaleY(this.grubberFlyBeam.transform.localScale.y * this.MANTIS_CHARM_SCALE);
                             }
@@ -231,7 +231,7 @@ namespace Modding.Patches
             ModHooks.AfterAttack(attackDir); //MOD API - Added
             if (!this.cState.attacking) return;       //MOD API - Added
             this.slashComponent.StartSlash();
-            if (this.playerData.equippedCharm_38)
+            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_38)))
             {
                 this.fsm_orbitShield.SendEvent("SLASH");
             }
@@ -851,7 +851,7 @@ namespace Modding.Patches
             Vector2 origVector;
 
             float velocity;
-            if (this.playerData.equippedCharm_16 && this.cState.shadowDashing)
+            if (this.playerData.GetBool(nameof(PlayerData.equippedCharm_16)) && this.cState.shadowDashing)
             {
                 velocity = this.DASH_SPEED_SHARP;
             }

--- a/Assembly-CSharp/Patches/InputHandler.cs
+++ b/Assembly-CSharp/Patches/InputHandler.cs
@@ -1,4 +1,4 @@
-﻿using MonoMod;
+using MonoMod;
 using UnityEngine;
 
 #pragma warning disable 1591
@@ -18,6 +18,9 @@ namespace Modding.Patches
         [MonoModIgnore]
         private bool controllerPressed;
 
+        [MonoModIgnore]
+        private GameManager gm;
+
         // Reverted cursor behavior
         [MonoModReplace]
         private void OnGUI()
@@ -31,7 +34,7 @@ namespace Modding.Patches
 
             if (!isMenuScene)
             {
-                ModHooks.OnCursor();
+                ModHooks.OnCursor(gm);
                 return;
             }
 

--- a/Assembly-CSharp/Patches/PlayerData.cs
+++ b/Assembly-CSharp/Patches/PlayerData.cs
@@ -83,25 +83,25 @@ namespace Modding.Patches
         [MonoModReplace]
         public void SetBool(string boolName, bool value)
         {
-            ModHooks.SetPlayerBool(boolName, value);
+            ModHooks.SetPlayerBool(boolName, value, this);
         }
 
         [MonoModReplace]
         public bool GetBool(string boolName)
         {
-            return ModHooks.GetPlayerBool(boolName);
+            return ModHooks.GetPlayerBool(boolName, this);
         }
 
         [MonoModReplace]
         public int GetInt(string intName)
         {
-            return ModHooks.GetPlayerInt(intName);
+            return ModHooks.GetPlayerInt(intName, this);
         }
 
         [MonoModReplace]
         public void SetInt(string intName, int value)
         {
-            ModHooks.SetPlayerInt(intName, value);
+            ModHooks.SetPlayerInt(intName, value, this);
         }
 
         [MonoModReplace]
@@ -109,7 +109,7 @@ namespace Modding.Patches
         {
             if (ReflectionHelper.GetFieldInfo(typeof(PlayerData), intName) != null)
             {
-                ModHooks.SetPlayerInt(intName, this.GetIntInternal(intName) + 1);
+                ModHooks.SetPlayerInt(intName, this.GetIntInternal(intName) + 1, this);
                 return;
             }
 
@@ -121,7 +121,7 @@ namespace Modding.Patches
         {
             if (ReflectionHelper.GetFieldInfo(typeof(PlayerData), intName) != null)
             {
-                ModHooks.SetPlayerInt(intName, this.GetIntInternal(intName) - 1);
+                ModHooks.SetPlayerInt(intName, this.GetIntInternal(intName) - 1, this);
             }
         }
 
@@ -130,7 +130,7 @@ namespace Modding.Patches
         {
             if (ReflectionHelper.GetFieldInfo(typeof(PlayerData), intName) != null)
             {
-                ModHooks.SetPlayerInt(intName, this.GetIntInternal(intName) + amount);
+                ModHooks.SetPlayerInt(intName, this.GetIntInternal(intName) + amount, this);
                 return;
             }
 
@@ -140,49 +140,49 @@ namespace Modding.Patches
         [MonoModReplace]
         public float GetFloat(string floatName)
         {
-            return ModHooks.GetPlayerFloat(floatName);
+            return ModHooks.GetPlayerFloat(floatName, this);
         }
 
         [MonoModReplace]
         public void SetFloat(string floatName, float value)
         {
-            ModHooks.SetPlayerFloat(floatName, value);
+            ModHooks.SetPlayerFloat(floatName, value, this);
         }
 
         [MonoModReplace]
         public string GetString(string stringName)
         {
-            return ModHooks.GetPlayerString(stringName);
+            return ModHooks.GetPlayerString(stringName, this);
         }
 
         [MonoModReplace]
         public void SetString(string stringName, string value)
         {
-            ModHooks.SetPlayerString(stringName, value);
+            ModHooks.SetPlayerString(stringName, value, this);
         }
 
         [MonoModReplace]
         public Vector3 GetVector3(string vector3Name)
         {
-            return ModHooks.GetPlayerVector3(vector3Name);
+            return ModHooks.GetPlayerVector3(vector3Name, this);
         }
 
         [MonoModReplace]
         public void SetVector3(string vector3Name, Vector3 value)
         {
-            ModHooks.SetPlayerVector3(vector3Name, value);
+            ModHooks.SetPlayerVector3(vector3Name, value, this);
         }
 
         [MonoModReplace]
         public T GetVariable<T>(string varName)
         {
-            return ModHooks.GetPlayerVariable<T>(varName);
+            return ModHooks.GetPlayerVariable<T>(varName, this);
         }
 
         [MonoModReplace]
         public void SetVariable<T>(string varName, T value)
         {
-            ModHooks.SetPlayerVariable<T>(varName, value);
+            ModHooks.SetPlayerVariable<T>(varName, value, this);
         }
 
         public extern void orig_TakeHealth(int amount);

--- a/Assembly-CSharp/Patches/PlayerData.cs
+++ b/Assembly-CSharp/Patches/PlayerData.cs
@@ -1,4 +1,4 @@
-﻿using MonoMod;
+using MonoMod;
 using UnityEngine;
 
 // ReSharper disable All
@@ -198,7 +198,7 @@ namespace Modding.Patches
         public void UpdateBlueHealth()
         {
             orig_UpdateBlueHealth();
-            healthBlue += ModHooks.OnBlueHealth();
+            SetInt(nameof(healthBlue), GetInt(nameof(healthBlue)) + ModHooks.OnBlueHealth());
         }
 
         public extern void orig_AddHealth(int amount);

--- a/PrePatcher/Program.cs
+++ b/PrePatcher/Program.cs
@@ -53,9 +53,7 @@ namespace Prepatcher
 
             foreach (TypeDefinition type in module.Types.Where(type => type.HasMethods))
             {
-                IEnumerable<MethodDefinition> patchableMethods = type.Methods.Concat(type.NestedTypes.SelectMany(type => type.Methods));
-
-                foreach (MethodDefinition method in patchableMethods)
+                foreach (MethodDefinition method in GetMethodsRecursively(type))
                 {
                     if
                     (
@@ -139,6 +137,31 @@ namespace Prepatcher
             module.Write(args[1]);
 
             Console.WriteLine("Changed " + changes + " get/set calls");
+        }
+
+        /// <summary>
+        /// Yields all methods defined on the given type, or a (recursively) nested type within the given type
+        /// </summary>
+        private static IEnumerable<MethodDefinition> GetMethodsRecursively(TypeDefinition type)
+        {
+            if (type.HasMethods)
+            {
+                foreach (MethodDefinition method in type.Methods)
+                {
+                    yield return method;
+                }
+            }
+
+            if (type.HasNestedTypes)
+            {
+                foreach (TypeDefinition nested in type.NestedTypes)
+                {
+                    foreach (MethodDefinition method in GetMethodsRecursively(nested))
+                    {
+                        yield return method;
+                    }
+                }
+            }
         }
 
         private static void SwapStFld

--- a/PrePatcher/Program.cs
+++ b/PrePatcher/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Mono.Cecil;
@@ -52,7 +53,9 @@ namespace Prepatcher
 
             foreach (TypeDefinition type in module.Types.Where(type => type.HasMethods))
             {
-                foreach (MethodDefinition method in type.Methods)
+                IEnumerable<MethodDefinition> patchableMethods = type.Methods.Concat(type.NestedTypes.SelectMany(type => type.Methods));
+
+                foreach (MethodDefinition method in patchableMethods)
                 {
                     if
                     (


### PR DESCRIPTION
Summary of changes:
- References to fake singletons (PlayerData.Instance, HeroController.Instance etc) in ModHooks are removed.
- The prepatcher is updated to patch methods on nested types - this is most important with IEnumerator methods but there are some patched methods which it seems are generated from inline delegates.
- HeroController, GameManager and PlayerData have patched methods changed to correctly use GetBool rather than field accesses. (I'm not sure if all of these methods are supposed to behave like this, but if any are not then I think it would be nice to explicitly exclude them in the PrePatcher even if it would be redundant.)