### PR TITLE
Prevent passing through ModHooks twice in a single TakeHealth call

### DIFF
--- a/Assembly-CSharp/GlobalSuppressions.cs
+++ b/Assembly-CSharp/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿
+
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 
@@ -10,7 +10,6 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Modding.Patches.GameManager.orig_ClearSaveFile(System.Int32)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Modding.Patches.HeroController.orig_TakeDamage(UnityEngine.GameObject,GlobalEnums.CollisionSide,System.Int32,System.Int32)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Modding.Patches.HeroController.orig_StartMPDrain(System.Single)")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Modding.Patches.PlayerData.orig_TakeHealth(System.Int32)")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Modding.Patches.PlayerData.orig_UpdateBlueHealth")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~M:Modding.Patches.PlayerData.orig_SetupNewPlayerData")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "member", Target = "~P:Modding.Patches.PlayerData.instance")]


### PR DESCRIPTION
In `PlayerData.orig_TakeHealth` there is a call to `PlayerData.TakeHealth`, which cause a part of the `amount` is passed through `ModHooks.TakeHealthHook` twice. This results in counter-intuitive behaviour.

For example, if a mod hooks `ModHooks.TakeHealthHook` with `damage => damage * 2` in order to double all the damage, then because of the above described mechanic, when the player have lifeblood and the damage exceeds lifeblood amount, the exceeding part of the damage will be doubled twice. (Same as the old bug in the base game)

AFAIK currently no mod relies on this mechanic or does something with `PlayerData.orig_TakeHealth`, so it will be a safe change.