### PR TITLE
Prevent atlas-packed images from being flipped

### DIFF
--- a/Assembly-CSharp/CanvasUtil.cs
+++ b/Assembly-CSharp/CanvasUtil.cs
@@ -321,6 +321,7 @@ namespace Modding
             Image img = panel.AddComponent<Image>();
             img.sprite = sprite;
             img.preserveAspect = true;
+            img.useSpriteMesh = true;
             return panel;
         }
 


### PR DESCRIPTION
By default, Unity UI images do not respect packing orientation. This means that sprites that have been packed flipped or rotated will appear flipped or rotated when using CreateImagePanel. `useSpriteMesh` fixes this (lack of) behavior by creating a mesh that respects the UV coordinates of the sprite, like `SpriteRenderer` does.