### PR TITLE
Option to override global settings

### DIFF
--- a/Assembly-CSharp/Mod.cs
+++ b/Assembly-CSharp/Mod.cs
@@ -99,10 +99,24 @@ namespace Modding
 
             Log("Initializing");
 
-            _globalSettingsPath ??= Path.Combine(Application.persistentDataPath, $"{GetType().Name}.GlobalSettings.json");
+            _globalSettingsPath ??= GetGlobalSettingsPath();
 
             LoadGlobalSettings();
             HookSaveMethods();
+        }
+
+        private string GetGlobalSettingsPath()
+        {
+            string globalSettingsFileName = $"{GetType().Name}.GlobalSettings.json";
+
+            string location = GetType().Assembly.Location;
+            string directory = Path.GetDirectoryName(location);
+            string globalSettingsOverride = Path.Combine(directory, globalSettingsFileName);
+
+            if (File.Exists(globalSettingsOverride))
+                return globalSettingsOverride;
+
+            return Path.Combine(Application.persistentDataPath, globalSettingsFileName);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
We override the global settings if there is a file called ModName.GlobalSettings.json in the mod's folder.

Use case: this means that mod packs can be distributed where some mods come with global settings prepackaged (e.g. for races or multiplayer games).

Draft pull request because I'm awaiting test results from the people who care about this sort of thing.