### PR TITLE
Actually draw black borders after ModHooks.DrawBlackBordersHook

### DIFF
--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -24,7 +24,7 @@ namespace Modding
     [PublicAPI]
     public class ModHooks
     {
-        private const int _modVersion = 72;
+        private const int _modVersion = 73;
 
         private static readonly string SettingsPath = Path.Combine(Application.persistentDataPath, "ModdingApi.GlobalSettings.json");
 

--- a/Assembly-CSharp/Patches/SceneManager.cs
+++ b/Assembly-CSharp/Patches/SceneManager.cs
@@ -66,6 +66,11 @@ namespace Modding.Patches
             borders.Add(gameObject);
 
             ModHooks.OnDrawBlackBorders(borders);
+            
+            foreach (var border in borders)
+            {
+                UnityEngine.SceneManagement.SceneManager.MoveGameObjectToScene(border, base.gameObject.scene);
+            }
         }
 
         private extern void orig_Start();


### PR DESCRIPTION
The replacement for `SceneManager.DrawBlackBorders()` didn't actually put the borders in the scene, which led to differences in room dupe visibility between vanilla and modded installs. Subscribers to `ModHooks.DrawBlackBordersHook` will still be able to read and modify the list of borders before they are put into the scene.