### PR TITLE
Menu button label

### DIFF
--- a/Assembly-CSharp/IMod.cs
+++ b/Assembly-CSharp/IMod.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -46,5 +46,11 @@ namespace Modding
         /// </summary>
         /// <returns></returns>
         int LoadPriority();
+
+        /// <summary>
+        ///     Returns the text that should be displayed on the mod menu button, if there is one.
+        /// </summary>
+        /// <returns></returns>
+        string GetMenuButtonText();
     }
 }

--- a/Assembly-CSharp/Mod.cs
+++ b/Assembly-CSharp/Mod.cs
@@ -166,6 +166,13 @@ namespace Modding
         /// </summary>
         public virtual void Initialize() { }
 
+        /// <summary>
+        ///     If this mod defines a menu via the <see cref="IMenuMod"/> or <see cref="ICustomMenuMod"/> interfaces, override this method to 
+        ///     change the text of the button to jump to this mod's menu.
+        /// </summary>
+        /// <returns></returns>
+        public virtual string GetMenuButtonText() => $"{GetName()} {Language.Language.Get("MAIN_OPTIONS", "MainMenu")}";
+
         private void HookSaveMethods()
         {
             ModHooks.ApplicationQuitHook += SaveGlobalSettings;

--- a/Assembly-CSharp/ModListMenu.cs
+++ b/Assembly-CSharp/ModListMenu.cs
@@ -312,12 +312,12 @@ namespace Modding
 
         private static string GetModMenuButtonLabel(ModInstance modInst)
         {
-            if (modInst.GetType().GetCustomAttribute<ModMenuButtonLabelAttribute>() is ModMenuButtonLabelAttribute a)
+            if (modInst.Mod.GetType().GetCustomAttribute<ModMenuButtonLabelAttribute>() is ModMenuButtonLabelAttribute a)
                 return a.Label;
 
-            if ((modInst.Mod is ICustomMenuMod { ToggleButtonInsideMenu: true }
-                || modInst.Mod is IMenuMod { ToggleButtonInsideMenu: true })
-                && modInst.Mod is ITogglableMod)
+            if (modInst.Mod is ITogglableMod &&
+                (modInst.Mod is ICustomMenuMod { ToggleButtonInsideMenu: true }
+                || modInst.Mod is IMenuMod { ToggleButtonInsideMenu: true }))
                 return modInst.Name;
                 
             return $"{modInst.Name} {Lang.Get("MAIN_OPTIONS", "MainMenu")}";

--- a/Assembly-CSharp/ModListMenu.cs
+++ b/Assembly-CSharp/ModListMenu.cs
@@ -11,27 +11,6 @@ using System.Reflection;
 
 namespace Modding
 {
-    /// <summary>
-    /// Add this attribute to a mod class which implements IMenuMod or ICustomMenuMod to 
-    /// change the string of the button that jumps to the mod's menu.
-    /// 
-    /// The default is {mod.GetName()} or {mod.GetName()} Options, depending on
-    /// whether the mod is IToggleable with toggle button inside menu or not.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
-    public class ModMenuButtonLabelAttribute : Attribute
-    {
-        /// <summary>
-        /// The text to display on the mod menu button.
-        /// </summary>
-        public string Label { get; set; }
-
-        /// <summary>
-        /// Construct an instance of the ModMenuButtonLabelAttribute class.
-        /// </summary>
-        public ModMenuButtonLabelAttribute(string label) => Label = label;
-    }
-
     internal class ModListMenu
     {
         private MenuScreen screen;
@@ -166,7 +145,7 @@ namespace Modding
                                                 {
                                                     Style = MenuButtonStyle.VanillaStyle,
                                                     CancelAction = _ => this.ApplyChanges(),
-                                                    Label = GetModMenuButtonLabel(modInst),
+                                                    Label = modInst.Mod.GetMenuButtonText(),
                                                     SubmitAction = _ => ((Patch.UIManager)UIManager.instance)
                                                         .UIGoToDynamicMenu(menu),
                                                     Proceed = true,
@@ -195,7 +174,7 @@ namespace Modding
                                                 {
                                                     Style = MenuButtonStyle.VanillaStyle,
                                                     CancelAction = _ => this.ApplyChanges(),
-                                                    Label = GetModMenuButtonLabel(modInst),
+                                                    Label = modInst.Mod.GetMenuButtonText(),
                                                     SubmitAction = _ => ((Patch.UIManager)UIManager.instance)
                                                         .UIGoToDynamicMenu(menu),
                                                     Proceed = true,
@@ -309,18 +288,5 @@ namespace Modding
 
         private void GoToModListMenu(object _) => GoToModListMenu();
         private void GoToModListMenu() => ((Patch.UIManager)UIManager.instance).UIGoToDynamicMenu(this.screen);
-
-        private static string GetModMenuButtonLabel(ModInstance modInst)
-        {
-            if (modInst.Mod.GetType().GetCustomAttribute<ModMenuButtonLabelAttribute>() is ModMenuButtonLabelAttribute a)
-                return a.Label;
-
-            if (modInst.Mod is ITogglableMod &&
-                (modInst.Mod is ICustomMenuMod { ToggleButtonInsideMenu: true }
-                || modInst.Mod is IMenuMod { ToggleButtonInsideMenu: true }))
-                return modInst.Name;
-                
-            return $"{modInst.Name} {Lang.Get("MAIN_OPTIONS", "MainMenu")}";
-        }
     }
 }

--- a/Assembly-CSharp/ModListMenu.cs
+++ b/Assembly-CSharp/ModListMenu.cs
@@ -7,7 +7,6 @@ using UnityEngine.UI;
 using static Modding.ModLoader;
 using Patch = Modding.Patches;
 using Lang = Language.Language;
-using System.Reflection;
 
 namespace Modding
 {
@@ -288,5 +287,6 @@ namespace Modding
 
         private void GoToModListMenu(object _) => GoToModListMenu();
         private void GoToModListMenu() => ((Patch.UIManager)UIManager.instance).UIGoToDynamicMenu(this.screen);
+
     }
 }


### PR DESCRIPTION
Discussion Points:

1) Is this functionality we really want? (Forcing a uniform naming convention isn't an unreasonable take, though I do like being able to factor out the method to decide the button text)
2) Is this the best approach? (Should the attribute go on the method, or should it be another interface to control the text, or something else)
3) Should the menu button label be cached? Currently it's recomputed every time they return to menu, but it could be cached as an extra field on ModInstance (or maybe somehow else)