### PR TITLE
Log when an assembly with no mods is loaded

### DIFF
--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -214,7 +214,10 @@ namespace Modding
                 }
 
                 if (!foundMod)
-                    Logger.APILogger.Log($"No mods found in loaded assembly {asm.FullName}");
+                {
+                    AssemblyName info = asm.GetName();
+                    Logger.APILogger.Log($"Assembly {info.Name} ({info.Version}) loaded with 0 mods");
+                }
             }
 
             var scenes = new List<string>();

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -161,6 +161,8 @@ namespace Modding
             foreach (Assembly asm in asms)
             {
                 Logger.APILogger.LogDebug($"Loading mods in assembly `{asm.FullName}`");
+                
+                bool foundMod = false;
 
                 try
                 {
@@ -168,6 +170,8 @@ namespace Modding
                     {
                         if (!ty.IsClass || ty.IsAbstract || !ty.IsSubclassOf(typeof(Mod)))
                             continue;
+
+                        foundMod = true;
 
                         Logger.APILogger.LogDebug($"Constructing mod `{ty.FullName}`");
 
@@ -208,6 +212,9 @@ namespace Modding
                 {
                     Logger.APILogger.LogError(e);
                 }
+
+                if (!foundMod)
+                    Logger.APILogger.Log($"No mods found in loaded assembly {asm.FullName}");
             }
 
             var scenes = new List<string>();


### PR DESCRIPTION
Examples: Vasi, RandomizerCore

To appease the support people who get issues when users don't have Vasi/RC/etc installed for whatever reason.