### PR TITLE
Fix preloading bug

### DIFF
--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -243,7 +243,7 @@ namespace Modding
             // Setup dict of scene preloads
             GetPreloads(orderedMods, scenes, toPreload, sceneHooks);
             
-            if (toPreload.Count > 0)
+            if (toPreload.Count > 0 || sceneHooks.Count > 0)
             {
                 Preloader pld = coroutineHolder.GetOrAddComponent<Preloader>();
                 yield return pld.Preload(toPreload, preloadedObjects, sceneHooks);


### PR DESCRIPTION
Repro: if 0 mods request preloads through the standard mechanism but a mod requests preloads through the scene hooks