### PR TITLE
Add API for mods to interact with other mods' preloads

### DIFF
--- a/Assembly-CSharp/IMod.cs
+++ b/Assembly-CSharp/IMod.cs
@@ -30,6 +30,14 @@ namespace Modding
         (string, Func<IEnumerator>)[] PreloadSceneHooks();
 
         /// <summary>
+        /// This function will be invoked on each gameObject preloaded through the <see cref="GetPreloadNames"/> system.
+        /// </summary>
+        /// <param name="go">The preloaded gameObject.</param>
+        /// <param name="sceneName">The scene the gameObject was preloaded from.</param>
+        void InvokeOnGameObjectPreloaded(GameObject go, string sceneName);
+
+
+        /// <summary>
         ///     Called after preloading of all mods.
         /// </summary>
         /// <param name="preloadedObjects">The preloaded objects relevant to this <see cref="Mod" /></param>

--- a/Assembly-CSharp/Mod.cs
+++ b/Assembly-CSharp/Mod.cs
@@ -118,7 +118,7 @@ namespace Modding
                 Log("Overriding Global Settings path with Mod directory");
                 return globalSettingsOverride;
             }
-            
+
             return Path.Combine(Application.persistentDataPath, globalSettingsFileName);
         }
 
@@ -147,6 +147,13 @@ namespace Modding
         /// </summary>
         /// <returns>List of tuples containg scene names and the respective actions.</returns>
         public virtual (string, Func<IEnumerator>)[] PreloadSceneHooks() => Array.Empty<(string, Func<IEnumerator>)>();
+
+        /// <summary>
+        /// This function will be invoked on each gameObject preloaded through the <see cref="GetPreloadNames"/> system.
+        /// </summary>
+        /// <param name="go">The preloaded gameObject.</param>
+        /// <param name="sceneName">The scene the gameObject was preloaded from.</param>
+        public virtual void InvokeOnGameObjectPreloaded(GameObject go, string sceneName) { }
 
         /// <inheritdoc />
         /// <summary>

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -249,6 +249,14 @@ namespace Modding
                 yield return pld.Preload(toPreload, preloadedObjects, sceneHooks);
             }
 
+            foreach ((string sceneName, Dictionary<string, GameObject> goMap) in preloadedObjects.Values.SelectMany(x => x))
+            {
+                foreach (GameObject go in goMap.Values)
+                {
+                    OnPreloadedObject(go, sceneName);
+                }
+            }
+
             foreach (ModInstance mod in orderedMods)
             {
                 if (mod.Error is not null)
@@ -464,6 +472,17 @@ namespace Modding
             }
 
             if (updateModText) UpdateModText();
+        }
+
+        public static void OnPreloadedObject(GameObject go, string sceneName)
+        {
+            foreach (ModInstance modInstance in ModInstances)
+            {
+                if (modInstance.Error is not null)
+                    continue;
+
+                modInstance.Mod.InvokeOnGameObjectPreloaded(go, sceneName);
+            }
         }
 
         // Essentially the state of a loaded **mod**. The assembly has nothing to do directly with mods.


### PR DESCRIPTION
TL;DR: This is the cleanest way to fix a bug in Custom Knight.

The rationale for this PR is as follows. Custom Knight has a feature where objects not associated with the knight can get skinned - for example, a skin might want to replace all copies of a grub with a custom sprite.

For base game items, the way this works is that the skin author declares that hash `568482B2D16BF50AE18B394EC15B290048B75DCD` is associated with the grub skin, and then CustomKnight looks up in a precomputed lookup [here](https://github.com/PrashantMohta/HollowKnight.CustomKnight/blob/aee70e3174b66036981adc2096240ae70667ddfc/CustomKnight/Res/hashcache.json#L1035) which scenes/objects need to be skinned.

Obviously this approach doesn't work if another mod has preloaded and instantiated grubs, because they won't be found in any of the listed scenes/paths.

The best approach we could come up with was for Custom Knight to add a component to preloaded objects to indicate where they originally came from, so for example if a mod preloaded a grub [like this](https://github.com/homothetyhk/HollowKnight.ItemChanger/blob/master/ItemChanger/Internal/Preloaders/GrubPreloader.cs#L7) then the data could be added as a component on the preloaded object to indicate the source of the preload (or similar). This method is added as an alternative to CK having to IL-Hook internal MAPI methods in the mod constructor.

---

Note - the new API is added as a virtual method rather than an event because the event would have to be subscribed before mod.Initialize, which is not ideal.