### PR TITLE
Update workflow to work with PRs.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,20 @@
 name: build
 
 on:
-  push:
-  pull_request:
+  workflow_call:
+    secrets:
+      BINARY_ARCHIVE_DEPLOY_KEY:
+        description: Deploy key to read from the binary archive repository.
+        required: true
+    inputs:
+      ref:
+        description: The ref to checkout.
+        required: true
+        type: string
+      upload-artifact:
+        description: Whether artifacts should be uploaded.
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -13,6 +25,9 @@ jobs:
         archive-ref: [main]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
       
       - name: Read Versions
         run: |
@@ -29,6 +44,7 @@ jobs:
             ${{ env.HK_VERSION }}/managed.${{ matrix.platform }}.tar.gz
           sparse-checkout-cone-mode: false
           path: ./hk-binary-archives
+          persist-credentials: false
       
       - name: Unpack Archive
         run: |
@@ -53,57 +69,8 @@ jobs:
         run: |
           dotnet build Assembly-CSharp -p:SolutionDir=$PWD -p:Configuration=Release
       - name: Upload Binary
+        if: inputs.upload-artifact
         uses: actions/upload-artifact@v4
         with:
           name: build.${{ matrix.platform }}
           path: ./OutputFinal/
-  
-  release:
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags')
-    steps:
-      - uses: actions/checkout@v4
-        
-      - name: Read Versions
-        run: |
-          HKV=$(cat ./hollowknight.version)
-          echo "HK_VERSION=$HKV" >> $GITHUB_ENV
-          
-          APIV=$(cat ./moddingapi.version)
-          echo "API_VERSION=$APIV" >> $GITHUB_ENV
-        
-      - uses: actions/download-artifact@v4
-        with:
-          path: ./artifacts
-      - name: Zip Artifacts
-        run: |
-            zip -jr moddingapi.${{ env.API_VERSION }}.windows.zip ./artifacts/build.windows/*
-            zip -jr moddingapi.${{ env.API_VERSION }}.macos.zip ./artifacts/build.macos/*
-            zip -jr moddingapi.${{ env.API_VERSION }}.linux.zip ./artifacts/build.linux/*
-      
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-      - name: Install Node Dependencies
-        run: |
-          npm install handlebars
-      - name: Create Release Notes
-        id: create-relnotes
-        uses: actions/github-script@v7
-        env:
-          CHANGELOG: ${{ github.event.head_commit.message }}
-        with:
-          result-encoding: string
-          script: |
-            const script = require("./.github/workflows/create_relnotes.js");
-            return await script();
-      
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: ${{ steps.create-relnotes.outputs.result }}
-          files: |
-            ./moddingapi.${{ env.API_VERSION }}.windows.zip
-            ./moddingapi.${{ env.API_VERSION }}.macos.zip
-            ./moddingapi.${{ env.API_VERSION }}.linux.zip

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,21 @@
+name: pr
+
+on: [ pull_request_target ]
+
+permissions: read-all
+
+jobs:
+  pr-build:
+    # Builds the pull request. This uses a workaround to lets pull requests build against
+    # the private repository, despite not having access. The binary archive deploy key is read only,
+    # and the permissions for the build script are all read-only, so this should not lead to any
+    # real vulnerability. It is not really a problem if the data in the archive repository is
+    # "leaked", we just want to keep it private out of principle.
+    uses: ./.github/workflows/build.yaml
+    permissions: read-all
+    secrets:
+      BINARY_ARCHIVE_DEPLOY_KEY: ${{ secrets.BINARY_ARCHIVE_DEPLOY_KEY }}
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      upload-artifact: false
+  

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,62 @@
+name: push
+
+on: [ push ]
+
+jobs:
+  push-build:
+    uses: ./.github/workflows/build.yaml
+    secrets:
+      BINARY_ARCHIVE_DEPLOY_KEY: ${{ secrets.BINARY_ARCHIVE_DEPLOY_KEY }}
+    with:
+      ref: ${{ github.ref }}
+      upload-artifact: true
+  
+  push-release:
+    needs: [push-build]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v4
+        
+      - name: Read Versions
+        run: |
+          HKV=$(cat ./hollowknight.version)
+          echo "HK_VERSION=$HKV" >> $GITHUB_ENV
+          
+          APIV=$(cat ./moddingapi.version)
+          echo "API_VERSION=$APIV" >> $GITHUB_ENV
+        
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+      - name: Zip Artifacts
+        run: |
+            zip -jr moddingapi.${{ env.API_VERSION }}.windows.zip ./artifacts/build.windows/*
+            zip -jr moddingapi.${{ env.API_VERSION }}.macos.zip ./artifacts/build.macos/*
+            zip -jr moddingapi.${{ env.API_VERSION }}.linux.zip ./artifacts/build.linux/*
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install Node Dependencies
+        run: |
+          npm install handlebars
+      - name: Create Release Notes
+        id: create-relnotes
+        uses: actions/github-script@v7
+        env:
+          CHANGELOG: ${{ github.event.head_commit.message }}
+        with:
+          result-encoding: string
+          script: |
+            const script = require("./.github/workflows/create_relnotes.js");
+            return await script();
+      
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.create-relnotes.outputs.result }}
+          files: |
+            ./moddingapi.${{ env.API_VERSION }}.windows.zip
+            ./moddingapi.${{ env.API_VERSION }}.macos.zip
+            ./moddingapi.${{ env.API_VERSION }}.linux.zip


### PR DESCRIPTION
This updates the workflow to work with PRs. Specifically, it allows external branches PRing against this repository to access the binary archive repository deploy key.

While this is potentially vulnerable, testing has determined that it is not. As described in `pr.yaml`, the `pull_request_target` workflow trigger can only activate the workflow in the base repository, not the workflow files in the PR. This means the only point of "vulnerability" would be the build script. However, the github token used in the `pr` workflow has read only access to this repository, and the SSH key to the archive repository is both used with `persist-credentials: false`, and is also read only. The only reason the archive repository is private is to not explicitly just redistribute base Hollow Knight assets publicly. It is not actually a catastrophic security vulnerability for the files in that repository to be leaked, considering anyone who has bought hollow knight could do the same.

56 and I tested these things and we determined it is safe to use.