### PR TITLE
Modified BlueHealth hooks to stack

### DIFF
--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -1179,7 +1179,7 @@ namespace Modding
             {
                 try
                 {
-                    result = toInvoke.Invoke();
+                    result += toInvoke.Invoke();
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This code change should enable multiple mods to utilize the BlueHealth hook, instead of 1 overriding all the others