### PR TITLE
Fix cancel action of horizontal option in menu utils

### DIFF
--- a/Assembly-CSharp/Menu/MenuUtils.cs
+++ b/Assembly-CSharp/Menu/MenuUtils.cs
@@ -100,7 +100,7 @@ namespace Modding.Menu
                     {
                         ApplySetting = (_, i) => entry.Saver(i),
                         RefreshSetting = (s, _) => s.optionList.SetOptionTo(entry.Loader()),
-                        CancelAction = _ => ((Patch.UIManager)UIManager.instance).GoToDynamicMenu(returnScreen),
+                        CancelAction = _ => ((Patch.UIManager)UIManager.instance).UIGoToDynamicMenu(returnScreen),
                         Description = string.IsNullOrEmpty(entry.Description) ? null : new DescriptionInfo
                         {
                             Text = entry.Description


### PR DESCRIPTION
The `MenuUtils` class contains an erroneous call to `UIManager#GoToDynamicMenu`, which instead should call `UIManager#UIGoToDynamicMenu`. The first returns the coroutine that the latter starts. Currently, the cancel action does not return the user to the menu screen denoted by `returnScreen`.