### PR TITLE
update github action dotnet version to 8.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,8 +53,6 @@ jobs:
           tar -xzf ../hk-binary-archives/${{ env.HK_VERSION }}/managed.${{ matrix.platform }}.tar.gz
       
       - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.x
       - name: Setup MSBuild
         run: |
           sudo apt-get update -y


### PR DESCRIPTION
6.0 is end of life since November 2024, 8.0 is LTS

motivated by #160 in which I use some modern language features