### PR TITLE
Instantiate preloads before passing them to mods

### DIFF
--- a/Assembly-CSharp/Preloader.cs
+++ b/Assembly-CSharp/Preloader.cs
@@ -195,7 +195,10 @@ internal class Preloader : MonoBehaviour
                         }
                         else
                         {
-                            modScenePreloads.Add(path, UnityEngine.Object.Instantiate(go));
+                            var modGo = Instantiate(go);
+                            DontDestroyOnLoad(modGo);
+                            modGo.SetActive(false);
+                            modScenePreloads.Add(path, modGo);
                         }
                     };
                     queue.Add(request);

--- a/Assembly-CSharp/Preloader.cs
+++ b/Assembly-CSharp/Preloader.cs
@@ -195,7 +195,7 @@ internal class Preloader : MonoBehaviour
                         }
                         else
                         {
-                            modScenePreloads.Add(path, go);
+                            modScenePreloads.Add(path, UnityEngine.Object.Instantiate(go));
                         }
                     };
                     queue.Add(request);


### PR DESCRIPTION
This can break things for mods which are expecting actual game objects rather than prefabs.

It seems this doesn't need to be done for RepackScene mode?