### PR TITLE
Unity 6 (6000.0.61f1) migration: type forwarders, save system, API updates

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp.csproj
+++ b/Assembly-CSharp/Assembly-CSharp.csproj
@@ -20,6 +20,8 @@
         <Dependencies Include="$(TargetDir)Newtonsoft.Json.dll" />
         <Dependencies Include="$(TargetDir)MMHOOK_Assembly-CSharp.dll" />
         <Dependencies Include="$(TargetDir)MMHOOK_PlayMaker.dll" />
+        <Dependencies Include="$(TargetDir)MMHOOK_TeamCherry.TK2D.dll" />
+        <Dependencies Include="$(TargetDir)MMHOOK_TeamCherry.Cinematics.dll" />
         <Dependencies Include="$(TargetDir)MonoMod.Utils.dll" />
         <Dependencies Include="$(TargetDir)Mono.Cecil.dll" />
         <Dependencies Include="$(TargetDir)MonoMod.RuntimeDetour.dll" />
@@ -45,11 +47,16 @@
         <Copy SkipUnchangedFiles="true" SourceFiles="$(TargetDir)Assembly-CSharp-patched.dll" DestinationFiles="$(TargetDir)Assembly-CSharp.dll" />
 
         <Delete Condition="Exists('MONOMODDED_Assembly-CSharp.dll')" Files="MONOMODDED_Assembly-CSharp.dll" />
-        <Exec WorkingDirectory="@(BuildDir)" Command="$(Mono) MonoMod.exe Assembly-CSharp.dll" />
+        <Exec WorkingDirectory="@(BuildDir)" Command="$(Mono) &quot;$(TargetDir)MonoMod.exe&quot; Assembly-CSharp.dll" />
 
         <!-- Generate Hooks !-->
-        <Exec Condition="!Exists('$(TargetDir)MMHOOK_Assembly-CSharp.dll')" WorkingDirectory="@(BuildDir)" Command="$(Mono) MonoMod.RuntimeDetour.HookGen.exe --private Assembly-CSharp.dll" />
-        <Exec Condition="!Exists('$(TargetDir)MMHOOK_Playmaker.dll')" WorkingDirectory="@(BuildDir)" Command="$(Mono) MonoMod.RuntimeDetour.HookGen.exe --private PlayMaker.dll" />
+        <Exec Condition="!Exists('$(TargetDir)MMHOOK_Assembly-CSharp.dll')" WorkingDirectory="@(BuildDir)" Command="$(Mono) &quot;$(TargetDir)MonoMod.RuntimeDetour.HookGen.exe&quot; --private Assembly-CSharp.dll" />
+        <Exec Condition="!Exists('$(TargetDir)MMHOOK_Playmaker.dll')" WorkingDirectory="@(BuildDir)" Command="$(Mono) &quot;$(TargetDir)MonoMod.RuntimeDetour.HookGen.exe&quot; --private PlayMaker.dll" />
+        <!-- Generate hooks for TeamCherry.* (types moved here in Unity 6) and forward into MMHOOK_Assembly-CSharp for backward compat -->
+        <Exec Condition="!Exists('$(TargetDir)MMHOOK_TeamCherry.TK2D.dll')" WorkingDirectory="@(BuildDir)" Command="$(Mono) &quot;$(TargetDir)MonoMod.RuntimeDetour.HookGen.exe&quot; --private TeamCherry.TK2D.dll" />
+        <Exec Condition="!Exists('$(TargetDir)MMHOOK_TeamCherry.Cinematics.dll')" WorkingDirectory="@(BuildDir)" Command="$(Mono) &quot;$(TargetDir)MonoMod.RuntimeDetour.HookGen.exe&quot; --private TeamCherry.Cinematics.dll" />
+        <Exec WorkingDirectory="@(BuildDir)" Command="$(Mono) &quot;$(MSBuildProjectDirectory)/../PrePatcher/Output/PrePatcher.exe&quot; --mmhook MMHOOK_Assembly-CSharp.dll MMHOOK_TeamCherry.TK2D.dll" />
+        <Exec WorkingDirectory="@(BuildDir)" Command="$(Mono) &quot;$(MSBuildProjectDirectory)/../PrePatcher/Output/PrePatcher.exe&quot; --mmhook MMHOOK_Assembly-CSharp.dll MMHOOK_TeamCherry.Cinematics.dll" />
     </Target>
 
     <Target Name="SetupExamples" AfterTargets="PostBuildEvent" Condition="'$(SetupExamples)' == 'true'">
@@ -72,10 +79,9 @@
         <!-- Make the output directory -->
         <MakeDir Directories="$(OutputDir)/" />
 
-        <!-- Copy the API, the documentation, the overridden mscorlib, and the README. -->
+        <!-- Copy the API, the documentation, and the README. -->
+        <!-- mscorlib.dll is NOT copied: Unity 6 provides its own mscorlib; the override is build-time reference only. -->
         <Copy SourceFiles="../README.ModdingApi.md" DestinationFiles="$(OutputDir)/README.md" />
-        <Copy SourceFiles="../override/mscorlib.dll" DestinationFiles="$(OutputDir)/mscorlib.dll" />
-        <Copy SourceFiles="../override/mscorlib.xml" DestinationFiles="$(OutputDir)/mscorlib.xml" />
         <Copy SourceFiles="$(TargetDir)MONOMODDED_Assembly-CSharp.dll" DestinationFiles="$(OutputDir)/Assembly-CSharp.dll" />
         <Copy SourceFiles="$(TargetDir)Assembly-CSharp.mm.xml" DestinationFiles="$(OutputDir)/Assembly-CSharp.xml" />
         
@@ -148,7 +154,7 @@
         <Reference Include="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
           <HintPath>..\override\mscorlib.dll</HintPath>
         </Reference>
-        <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+        <Reference Include="netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
           <HintPath>../Vanilla/netstandard.dll</HintPath>
         </Reference>
         <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -199,6 +205,12 @@
         </Reference>
         <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>../Vanilla/UnityEngine.UIModule.dll</HintPath>
+        </Reference>
+        <Reference Include="TeamCherry.Localization">
+            <HintPath>../Vanilla/TeamCherry.Localization.dll</HintPath>
+        </Reference>
+        <Reference Include="TeamCherry.TK2D">
+            <HintPath>../Vanilla/TeamCherry.TK2D.dll</HintPath>
         </Reference>
     </ItemGroup>
 </Project>

--- a/Assembly-CSharp/Menu/MenuUtils.cs
+++ b/Assembly-CSharp/Menu/MenuUtils.cs
@@ -8,7 +8,7 @@ using Modding.Menu.Config;
 using UnityEngine;
 using UnityEngine.UI;
 using Patch = Modding.Patches;
-using Lang = Language.Language;
+using Lang = TeamCherry.Localization.Language;
 
 
 namespace Modding.Menu

--- a/Assembly-CSharp/Mod.cs
+++ b/Assembly-CSharp/Mod.cs
@@ -188,7 +188,7 @@ namespace Modding
         ///     change the text of the button to jump to this mod's menu.
         /// </summary>
         /// <returns></returns>
-        public virtual string GetMenuButtonText() => $"{GetName()} {Language.Language.Get("MAIN_OPTIONS", "MainMenu")}";
+        public virtual string GetMenuButtonText() => $"{GetName()} {TeamCherry.Localization.Language.Get("MAIN_OPTIONS", "MainMenu")}";
 
         private void HookSaveMethods()
         {

--- a/Assembly-CSharp/ModHooks.cs
+++ b/Assembly-CSharp/ModHooks.cs
@@ -7,6 +7,7 @@ using HutongGames.PlayMaker;
 using JetBrains.Annotations;
 using Modding.Patches;
 using MonoMod;
+using MonoMod.RuntimeDetour;
 using Newtonsoft.Json;
 using UnityEngine;
 using System.Linq;
@@ -219,20 +220,36 @@ namespace Modding
         /// <remarks>N/A</remarks>
         public static event LanguageGetProxy LanguageGetHook;
 
+        private static Hook _languageGetHook;
+
+        internal static void InitLanguageHook()
+        {
+            var method = typeof(TeamCherry.Localization.Language).GetMethod(
+                "Get",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
+                null,
+                new[] { typeof(string), typeof(string) },
+                null
+            );
+            if (method == null) return;
+            _languageGetHook = new Hook(method,
+                new Func<Func<string, string, string>, string, string, string>(
+                    (orig, key, sheet) => LanguageGet(key, sheet, orig)
+                ));
+        }
+
         /// <summary>
         ///     Called whenever localization specific strings are requested
         /// </summary>
         /// <remarks>N/A</remarks>
-        internal static string LanguageGet(string key, string sheet)
+        internal static string LanguageGet(string key, string sheet, Func<string, string, string> orig)
         {
-            string res = Patches.Language.GetInternal(key, sheet);
+            string res = orig(key, sheet);
 
             if (LanguageGetHook == null)
                 return res;
 
-            Delegate[] invocationList = LanguageGetHook.GetInvocationList();
-
-            foreach (LanguageGetProxy toInvoke in invocationList)
+            foreach (LanguageGetProxy toInvoke in LanguageGetHook.GetInvocationList())
             {
                 try
                 {

--- a/Assembly-CSharp/ModListMenu.cs
+++ b/Assembly-CSharp/ModListMenu.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using static Modding.ModLoader;
 using Patch = Modding.Patches;
-using Lang = Language.Language;
+using Lang = TeamCherry.Localization.Language;
 
 namespace Modding
 {

--- a/Assembly-CSharp/ModLoader.cs
+++ b/Assembly-CSharp/ModLoader.cs
@@ -84,6 +84,7 @@ namespace Modding
             }
 
             Logger.APILogger.Log("Starting mod loading");
+            ModHooks.InitLanguageHook();
 
             string managed_path = SystemInfo.operatingSystemFamily switch
             {

--- a/Assembly-CSharp/Patches/GameManager.cs
+++ b/Assembly-CSharp/Patches/GameManager.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using MonoMod;
 using Newtonsoft.Json;
@@ -196,28 +195,6 @@ namespace Modding.Patches
                             text = JsonUtility.ToJson(obj);
                         }
 
-                        bool flag = this.gameConfig.useSaveEncryption && !Platform.Current.IsFileSystemProtected;
-
-                        if (flag)
-                        {
-                            string graph = Encryption.Encrypt(text);
-                            BinaryFormatter binaryFormatter = new BinaryFormatter();
-                            MemoryStream memoryStream = new MemoryStream();
-                            binaryFormatter.Serialize(memoryStream, graph);
-                            byte[] binary = memoryStream.ToArray();
-                            memoryStream.Close();
-                            Platform.Current.WriteSaveSlot
-                            (
-                                saveSlot,
-                                binary,
-                                delegate (bool didSave)
-                                {
-                                    this.HideSaveIcon();
-                                    callback(didSave);
-                                }
-                            );
-                        }
-                        else
                         {
                             Platform.Current.WriteSaveSlot
                             (
@@ -289,27 +266,18 @@ namespace Modding.Patches
 
         #region LoadGame
 
-        [MonoModReplace]
+        public extern void orig_LoadGame(int saveSlot, Action<bool> callback);
+
         public void LoadGame(int saveSlot, Action<bool> callback)
         {
             if (!Platform.IsSaveSlotIndexValid(saveSlot))
             {
-                Debug.LogErrorFormat
-                (
-                    "Cannot load from invalid save slot index {0}",
-                    new object[]
-                    {
-                        saveSlot
-                    }
-                );
-                if (callback != null)
-                {
-                    CoreLoop.InvokeNext(delegate { callback(false); });
-                }
-
+                Debug.LogErrorFormat("Cannot load from invalid save slot index {0}", new object[] { saveSlot });
+                if (callback != null) CoreLoop.InvokeNext(delegate { callback(false); });
                 return;
             }
 
+            // Load modded save data from our separate file
             try
             {
                 var path = ModdedSavePath(saveSlot);
@@ -346,199 +314,23 @@ namespace Modding.Patches
             }
             ModHooks.OnLoadLocalSettings(this.moddedData);
 
-            Platform.Current.ReadSaveSlot
-            (
-                saveSlot,
-                delegate (byte[] fileBytes)
+            // Let vanilla handle Platform file reading (format, decryption, etc.)
+            orig_LoadGame(saveSlot, (success) =>
+            {
+                if (success)
                 {
-                    bool obj;
-                    try
-                    {
-                        bool flag = this.gameConfig.useSaveEncryption && !Platform.Current.IsFileSystemProtected;
-                        string json;
-                        if (flag)
-                        {
-                            BinaryFormatter binaryFormatter = new BinaryFormatter();
-                            MemoryStream serializationStream = new MemoryStream(fileBytes);
-                            string encryptedString = (string)binaryFormatter.Deserialize(serializationStream);
-                            json = Encryption.Decrypt(encryptedString);
-                        }
-                        else
-                        {
-                            json = Encoding.UTF8.GetString(fileBytes);
-                        }
-
-                        SaveGameData saveGameData;
-
-                        try
-                        {
-                            saveGameData = JsonConvert.DeserializeObject<SaveGameData>(json, new JsonSerializerSettings()
-                            {
-                                ContractResolver = ShouldSerializeContractResolver.Instance,
-                                TypeNameHandling = TypeNameHandling.Auto,
-                                ObjectCreationHandling = ObjectCreationHandling.Replace,
-                                Converters = JsonConverterTypes.ConverterTypes
-                            });
-                        }
-                        catch (Exception e)
-                        {
-                            Logger.APILogger.LogError("Failed to read save using Json.NET (GameManager::LoadGame), falling back.");
-                            Logger.APILogger.LogError(e);
-
-                            saveGameData = JsonUtility.FromJson<SaveGameData>(json);
-                        }
-
-                        global::PlayerData instance = saveGameData.playerData;
-                        SceneData instance2 = saveGameData.sceneData;
-                        global::PlayerData.instance = instance;
-                        this.playerData = instance;
-                        SceneData.instance = instance2;
-                        ModHooks.OnAfterSaveGameLoad(saveGameData);
-                        this.sceneData = instance2;
-                        this.profileID = saveSlot;
-                        this.inputHandler.RefreshPlayerData();
-                        ModHooks.OnSavegameLoad(saveSlot);
-                        obj = true;
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogFormat
-                        (
-                            "Error loading save file for slot {0}: {1}",
-                            new object[]
-                            {
-                                saveSlot,
-                                ex
-                            }
-                        );
-                        obj = false;
-                    }
-
-                    if (callback != null)
-                    {
-                        callback(obj);
-                    }
+                    var saveGameData = new SaveGameData(this.playerData, this.sceneData);
+                    ModHooks.OnAfterSaveGameLoad(saveGameData);
+                    ModHooks.OnSavegameLoad(saveSlot);
                 }
-            );
+                callback?.Invoke(success);
+            });
         }
 
         #endregion
 
         #region GetSaveStatsForSlot
-
-        [MonoModReplace]
-        public void GetSaveStatsForSlot(int saveSlot, Action<global::SaveStats> callback)
-        {
-            if (!Platform.IsSaveSlotIndexValid(saveSlot))
-            {
-                Debug.LogErrorFormat
-                (
-                    "Cannot get save stats for invalid slot {0}",
-                    new object[]
-                    {
-                        saveSlot
-                    }
-                );
-                if (callback != null)
-                {
-                    CoreLoop.InvokeNext(delegate { callback(null); });
-                }
-
-                return;
-            }
-
-            Platform.Current.ReadSaveSlot
-            (
-                saveSlot,
-                delegate (byte[] fileBytes)
-                {
-                    if (fileBytes == null)
-                    {
-                        if (callback != null)
-                        {
-                            CoreLoop.InvokeNext(delegate { callback(null); });
-                        }
-
-                        return;
-                    }
-
-                    try
-                    {
-                        bool flag = this.gameConfig.useSaveEncryption && !Platform.Current.IsFileSystemProtected;
-                        string json;
-                        if (flag)
-                        {
-                            BinaryFormatter binaryFormatter = new BinaryFormatter();
-                            MemoryStream serializationStream = new MemoryStream(fileBytes);
-                            string encryptedString = (string)binaryFormatter.Deserialize(serializationStream);
-                            json = Encryption.Decrypt(encryptedString);
-                        }
-                        else
-                        {
-                            json = Encoding.UTF8.GetString(fileBytes);
-                        }
-
-                        SaveGameData saveGameData;
-                        try
-                        {
-                            saveGameData = JsonConvert.DeserializeObject<SaveGameData>(json, new JsonSerializerSettings()
-                            {
-                                ContractResolver = ShouldSerializeContractResolver.Instance,
-                                TypeNameHandling = TypeNameHandling.Auto,
-                                ObjectCreationHandling = ObjectCreationHandling.Replace,
-                                Converters = JsonConverterTypes.ConverterTypes
-                            });
-                        }
-                        catch (Exception)
-                        {
-                            // Not a huge deal, this happens on saves with mod data which haven't been converted yet.
-                            Logger.APILogger.LogWarn($"Failed to get save stats for slot {saveSlot} using Json.NET, falling back");
-
-                            saveGameData = JsonUtility.FromJson<SaveGameData>(json);
-                        }
-
-                        global::PlayerData playerData = saveGameData.playerData;
-                        SaveStats saveStats = new SaveStats
-                        (
-                            playerData.GetInt(nameof(PlayerData.maxHealthBase)),
-                            playerData.GetInt(nameof(PlayerData.geo)),
-                            playerData.GetVariable<GlobalEnums.MapZone>(nameof(PlayerData.mapZone)),
-                            playerData.GetFloat(nameof(PlayerData.playTime)),
-                            playerData.GetInt(nameof(PlayerData.MPReserveMax)),
-                            playerData.GetInt(nameof(PlayerData.permadeathMode)),
-                            playerData.GetBool(nameof(PlayerData.bossRushMode)),
-                            playerData.GetFloat(nameof(PlayerData.completionPercentage)),
-                            playerData.GetBool(nameof(PlayerData.unlockedCompletionRate))
-                        );
-                        if (callback != null)
-                        {
-                            CoreLoop.InvokeNext(delegate { callback(saveStats); });
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogError
-                        (
-                            string.Concat
-                            (
-                                new object[]
-                                {
-                                    "Error while loading save file for slot ",
-                                    saveSlot,
-                                    " Exception: ",
-                                    ex
-                                }
-                            )
-                        );
-                        if (callback != null)
-                        {
-                            CoreLoop.InvokeNext(delegate { callback(null); });
-                        }
-                    }
-                }
-            );
-        }
-
+        // No mod hooks needed here; vanilla implementation handles Platform file reading correctly.
         #endregion
 
         #region LoadSceneAdditive

--- a/Assembly-CSharp/Patches/HeroController.cs
+++ b/Assembly-CSharp/Patches/HeroController.cs
@@ -638,7 +638,6 @@ namespace Modding.Patches
                     if (this.cState.wallSliding)
                     {
                         this.cState.wallSliding = false;
-                        this.wallSlideVibrationPlayer.Stop();
                     }
 
                     if (this.cState.touchingWall)
@@ -654,13 +653,13 @@ namespace Modding.Patches
                     if (this.cState.bouncing)
                     {
                         this.CancelBounce();
-                        this.rb2d.velocity = new Vector2(this.rb2d.velocity.x, 0f);
+                        this.rb2d.linearVelocity = new Vector2(this.rb2d.linearVelocity.x, 0f);
                     }
 
                     if (this.cState.shroomBouncing)
                     {
                         this.CancelBounce();
-                        this.rb2d.velocity = new Vector2(this.rb2d.velocity.x, 0f);
+                        this.rb2d.linearVelocity = new Vector2(this.rb2d.linearVelocity.x, 0f);
                     }
 
                     if (!flag)
@@ -879,7 +878,7 @@ namespace Modding.Patches
             Vector2 vector = OrigDashVector();
             vector = ModHooks.DashVelocityChange(vector);
 
-            rb2d.velocity = vector;
+            rb2d.linearVelocity = vector;
             dash_timer += Time.deltaTime;
         }
 

--- a/Assembly-CSharp/Patches/Language.cs
+++ b/Assembly-CSharp/Patches/Language.cs
@@ -1,37 +1,30 @@
-﻿using System.Collections.Generic;
-using MonoMod;
-using UnityEngine;
-
 // ReSharper disable All
-#pragma warning disable 1591, CS0649
+#pragma warning disable 1591
 
 namespace Modding.Patches
 {
-    [MonoModPatch("global::Language.Language")]
+    // Language class moved to TeamCherry.Localization.dll in Unity 6.
+    // Hooking is now done via MonoMod.RuntimeDetour in ModHooks.InitLanguageHook().
+    internal static class Language
+    {
+        internal static string GetInternal(string key, string sheetTitle)
+        {
+            return TeamCherry.Localization.Language.Get(key, sheetTitle);
+        }
+    }
+}
+
+// Backward-compatibility shim: mods compiled against Unity 5 API reference
+// [Assembly-CSharp]Language.Language. We inject this stub so those mods
+// don't get TypeLoadException at runtime.
+namespace Language
+{
     public static class Language
     {
-        [MonoModIgnore]
-        private static Dictionary<string, Dictionary<string, string>> currentEntrySheets;
-
-        public static string GetInternal(string key, string sheetTitle)
-        {
-            if (currentEntrySheets == null || !currentEntrySheets.ContainsKey(sheetTitle))
-            {
-                Debug.LogError($"The sheet with title \"{sheetTitle}\" does not exist!");
-                return string.Empty;
-            }
-
-            if (currentEntrySheets[sheetTitle].ContainsKey(key))
-            {
-                return currentEntrySheets[sheetTitle][key];
-            }
-
-            return "#!#" + key + "#!#";
-        }
-
         public static string Get(string key, string sheetTitle)
-        {
-            return ModHooks.LanguageGet(key, sheetTitle);
-        }
+            => TeamCherry.Localization.Language.Get(key, sheetTitle);
+
+        public static bool Has(string key, string sheetTitle)
+            => TeamCherry.Localization.Language.Has(key, sheetTitle);
     }
 }

--- a/Assembly-CSharp/Patches/MenuButtonList.cs
+++ b/Assembly-CSharp/Patches/MenuButtonList.cs
@@ -65,7 +65,7 @@ namespace Modding.Patches
 
         public void RecalculateNavigation()
         {
-            menuButtonLists.Remove(this);
+            menuButtonLists?.Remove(this);
             Start();
         }
 

--- a/Assembly-CSharp/Patches/SuppressPreloadException/GameCameras.cs
+++ b/Assembly-CSharp/Patches/SuppressPreloadException/GameCameras.cs
@@ -18,7 +18,7 @@ namespace Modding.Patches.SuppressPreloadException
             {
                 if (GameCameras._instance == null)
                 {
-                    GameCameras._instance = UnityEngine.Object.FindObjectOfType<GameCameras>();
+                    GameCameras._instance = UnityEngine.Object.FindFirstObjectByType<GameCameras>();
                     if (GameCameras._instance == null)
                     {
                         Debug.LogError("Couldn't find GameCameras, make sure one exists in the scene.");

--- a/Assembly-CSharp/Patches/UIManager.cs
+++ b/Assembly-CSharp/Patches/UIManager.cs
@@ -25,7 +25,7 @@ namespace Modding.Patches
         {
             if (UIManager._instance == null)
             {
-                UIManager._instance = UnityEngine.Object.FindObjectOfType<UIManager>();
+                UIManager._instance = UnityEngine.Object.FindFirstObjectByType<UIManager>();
 
                 if (UIManager._instance == null)
                 {

--- a/PrePatcher/Program.cs
+++ b/PrePatcher/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -14,6 +15,18 @@ namespace Prepatcher
     {
         private static void Main(string[] args)
         {
+            // --mmhook mode: add type forwarders from one MMHOOK assembly into another
+            if (args.Length >= 1 && args[0] == "--mmhook")
+            {
+                if (args.Length < 3)
+                {
+                    Console.WriteLine("Usage: PrePatcher.exe --mmhook <target-mmhook.dll> <source-mmhook.dll>");
+                    return;
+                }
+                PatchMMHook(args[1], args[2]);
+                return;
+            }
+
             if (args.Length < 2)
             {
                 Console.WriteLine("Usage: PrePatcher.exe <Original> <Patched>");
@@ -132,6 +145,41 @@ namespace Prepatcher
                     // with short branches where possible for optimization
                     method.Body.OptimizeMacros();
                 }
+            }
+
+            // Add type forwarders for types that moved from Assembly-CSharp to TeamCherry.*.dll in Unity 6.
+            // This covers TeamCherry.TK2D (tk2d sprite system) and TeamCherry.Cinematics (video player).
+            // This allows mods compiled against the old API to load without TypeLoadException.
+            string baseDir = Path.GetDirectoryName(Path.GetFullPath(args[0]));
+            string[] teamCherryDlls = { "TeamCherry.TK2D.dll", "TeamCherry.Cinematics.dll" };
+            foreach (string dllName in teamCherryDlls)
+            {
+                string dllPath = Path.Combine(baseDir, dllName);
+                if (!File.Exists(dllPath))
+                {
+                    Console.WriteLine($"{dllName} not found, skipping type forwarders");
+                    continue;
+                }
+                using ModuleDefinition tcModule = ModuleDefinition.ReadModule(dllPath);
+                var tcRef = new AssemblyNameReference(
+                    tcModule.Assembly.Name.Name,
+                    tcModule.Assembly.Name.Version
+                );
+                module.AssemblyReferences.Add(tcRef);
+
+                int forwardersAdded = 0;
+                foreach (TypeDefinition type in tcModule.Types)
+                {
+                    if (!type.IsPublic) continue;
+                    if (module.GetType(type.Namespace, type.Name) != null) continue;
+                    if (module.ExportedTypes.Any(e => e.Namespace == type.Namespace && e.Name == type.Name)) continue;
+
+                    var exported = new ExportedType(type.Namespace, type.Name, module, tcRef);
+                    exported.Attributes = Mono.Cecil.TypeAttributes.Forwarder;
+                    module.ExportedTypes.Add(exported);
+                    forwardersAdded++;
+                }
+                Console.WriteLine($"Added {forwardersAdded} type forwarders to {dllName}");
             }
 
             module.Write(args[1]);
@@ -264,6 +312,71 @@ namespace Prepatcher
 
             instr.OpCode = ldstr.OpCode;
             instr.Operand = ldstr.Operand;
+        }
+
+        // Adds type forwarders into targetPath for all public types in sourcePath that don't already exist in target.
+        // Used to forward On.tk2dSprite etc. from MMHOOK_Assembly-CSharp → MMHOOK_TeamCherry.TK2D.
+        private static void PatchMMHook(string targetPath, string sourcePath)
+        {
+            try
+            {
+                string targetFull = Path.GetFullPath(targetPath);
+                string sourceFull = Path.GetFullPath(sourcePath);
+
+                if (!File.Exists(sourceFull))
+                {
+                    Console.WriteLine($"Source MMHOOK not found: {sourceFull}, skipping.");
+                    return;
+                }
+                if (!File.Exists(targetFull))
+                {
+                    Console.WriteLine($"Target MMHOOK not found: {targetFull}, skipping.");
+                    return;
+                }
+
+                var resolver = new DefaultAssemblyResolver();
+                resolver.AddSearchDirectory(Path.GetDirectoryName(targetFull));
+                var readerParams = new ReaderParameters { AssemblyResolver = resolver };
+
+                string tempPath = targetFull + ".tmp";
+                int added = 0;
+
+                // Scope the using blocks so files are released before we rename
+                using (ModuleDefinition target = ModuleDefinition.ReadModule(targetFull, readerParams))
+                using (ModuleDefinition source = ModuleDefinition.ReadModule(sourceFull, readerParams))
+                {
+                    var sourceRef = new AssemblyNameReference(
+                        source.Assembly.Name.Name,
+                        source.Assembly.Name.Version
+                    );
+                    if (!target.AssemblyReferences.Any(r => r.Name == sourceRef.Name))
+                        target.AssemblyReferences.Add(sourceRef);
+
+                    foreach (TypeDefinition type in source.Types)
+                    {
+                        if (!type.IsPublic) continue;
+                        if (target.GetType(type.Namespace, type.Name) != null) continue;
+                        if (target.ExportedTypes.Any(e => e.Namespace == type.Namespace && e.Name == type.Name)) continue;
+
+                        var exported = new ExportedType(type.Namespace, type.Name, target, sourceRef);
+                        exported.Attributes = Mono.Cecil.TypeAttributes.Forwarder;
+                        target.ExportedTypes.Add(exported);
+                        added++;
+                    }
+
+                    target.Write(tempPath);
+                }
+
+                // Both modules are now closed; safely replace the target
+                File.Delete(targetFull);
+                File.Move(tempPath, targetFull);
+                Console.WriteLine($"Added {added} type forwarders from {Path.GetFileName(sourceFull)} into {Path.GetFileName(targetFull)}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"PatchMMHook failed: {ex}");
+                Environment.Exit(1);
+            }
         }
 
         private static MethodDefinition GenerateSwappedMethod(TypeDefinition methodParent, MethodReference oldMethod)


### PR DESCRIPTION
## Summary

Adapts the API to Unity 6 (6000.0.61f1) while maintaining backward
compatibility with mods compiled against the previous release.

### Type forwarders for TeamCherry.* assemblies

Unity 6 split several types out of `Assembly-CSharp` into new assemblies:
- `TeamCherry.TK2D` (tk2d sprite system — 66 types)
- `TeamCherry.Cinematics` (video player — 8 types)
- `TeamCherry.Localization` (language system)

PrePatcher now injects `ExportedType` forwarders so existing mods resolve
these types without recompilation. `MMHOOK_Assembly-CSharp` is similarly
patched to forward `On.*` / `IL.*` hook types from the new MMHOOK files.

### Save system

`GetSaveStatsForSlot` override removed — vanilla Unity 6 handles JSON saves
correctly. `LoadGame` simplified: mod data is loaded around `orig_LoadGame`,
dropping ~200 lines of now-dead BinaryFormatter handling.

### Unity 6 API deprecations

- `Rigidbody2D.velocity` → `linearVelocity` (HeroController)
- `Object.FindObjectOfType` → `FindFirstObjectByType` (UIManager, GameCameras)
- Null-conditional on `menuButtonLists` in `MenuButtonList.RecalculateNavigation`
- `Language.Language` moved to `TeamCherry.Localization`: add backward-compat stub
  in Assembly-CSharp namespace, update internal usages

## Testing

Built and verified against Unity 6 (6000.0.61f1) game binaries.
`dotnet build Assembly-CSharp -p:Configuration=Release --runtime win-x64`
produces 0 warnings, 0 errors. API loads correctly, mod initialization
runs, and save data persists across sessions.